### PR TITLE
Milestone 8: Home page navigation launchpad and learn path stub

### DIFF
--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -1,0 +1,23 @@
+export default function LearnPage() {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <div className="max-w-4xl mx-auto px-6 py-16 space-y-4">
+        <h1 className="text-3xl font-light tracking-tight mb-2">
+          Learn path (coming soon)
+        </h1>
+        <p className="text-muted max-w-xl">
+          This page will become the curriculum hub, where you can see milestones,
+          unlock new topics, and follow a guided path through notes, scales,
+          chords, the circle of fifths, and eventually modes and advanced harmony.
+        </p>
+        <p className="text-sm text-muted">
+          For now, you can still use{" "}
+          <span className="font-medium">Practice</span>,{" "}
+          <span className="font-medium">Circle of fifths</span>, and{" "}
+          <span className="font-medium">Progress</span> from the home page.
+        </p>
+      </div>
+    </main>
+  );
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,45 +1,119 @@
-"use client";
-
+import Link from "next/link";
 import { PianoRollDemo } from "@/components/piano-roll/PianoRollDemo";
 
-export default function Home() {
+export default function HomePage() {
   return (
     <main className="min-h-screen bg-background text-foreground">
-      {/* Hero Section */}
-      <div className="max-w-4xl mx-auto px-6 py-16">
-        <section className="bg-surface border border-subtle rounded-2xl shadow-sm px-8 py-10 md:px-10 md:py-12 transition-all duration-200 ease-out hover:-translate-y-0.5 hover:shadow-md">
-          {/* Badge/Pill */}
-          <div className="inline-flex items-center gap-2 rounded-full border border-subtle bg-surface-muted px-3 py-1 text-xs font-medium text-muted">
-            <span>Harmonia</span>
-            <span className="h-1 w-1 rounded-full bg-accent" />
-            <span>Music theory for producers</span>
+      <div className="max-w-5xl mx-auto px-6 py-16 space-y-12">
+        {/* Hero */}
+        <section className="bg-surface border border-subtle rounded-2xl shadow-sm p-8 md:p-10">
+          <div className="inline-flex items-center gap-2 rounded-full border border-subtle px-3 py-1 text-xs font-medium text-muted mb-4">
+            <span className="h-1.5 w-1.5 rounded-full bg-foreground" />
+            Harmonia · Music theory for producers
           </div>
-
-          {/* Hero Title and Subtitle */}
-          <h1 className="mt-6 text-4xl md:text-5xl font-light tracking-tight text-foreground">
+          <h1 className="text-4xl md:text-5xl font-light tracking-tight mb-4">
             Learn harmony visually.
           </h1>
-          <p className="mt-3 text-sm md:text-base text-muted max-w-xl">
-            Interactive piano roll, circle of fifths, and spaced repetition designed for electronic music producers.
+          <p className="text-muted max-w-2xl mb-6">
+            Harmonia helps you internalize scales, chords, and the circle of fifths
+            using a piano-roll interface, spaced repetition, and producer–friendly
+            examples for EDM and bass music.
           </p>
-
-          {/* CTA Buttons */}
-          <div className="mt-6 flex flex-wrap items-center gap-3">
-            <button className="inline-flex items-center rounded-full bg-accent px-4 py-2 text-sm font-medium text-surface shadow-sm transition-colors duration-150 hover:bg-foreground">
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/practice"
+              className="inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-medium bg-foreground text-surface hover:-translate-y-0.5 hover:shadow-md transition"
+            >
               Start practicing
-            </button>
-            <button className="inline-flex items-center rounded-full border border-subtle bg-surface px-4 py-2 text-sm font-medium text-muted hover:bg-surface-muted transition-colors duration-150">
-              View theory roadmap
-            </button>
+            </Link>
+            <Link
+              href="/circle"
+              className="inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-medium border border-subtle text-foreground bg-surface hover:bg-surface-muted transition"
+            >
+              Explore the circle of fifths
+            </Link>
+          </div>
+        </section>
+
+        {/* Launchpad */}
+        <section className="space-y-4">
+          <div className="flex items-baseline justify-between gap-2">
+            <h2 className="text-lg font-medium">What would you like to work on?</h2>
+            <p className="text-xs text-muted">
+              All core pages are accessible from here.
+            </p>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            {/* Curriculum / Learn */}
+            <HomeNavCard
+              href="/learn"
+              title="Learn path"
+              badge="Curriculum"
+              description="Follow a structured path through notes, scales, chords, and the circle of fifths. Great when you want a clear next step."
+            />
+
+            {/* Flashcard practice */}
+            <HomeNavCard
+              href="/practice"
+              title="Practice cards"
+              badge="Daily SRS"
+              description="Run through smart flashcards with spaced repetition to actually remember chord spellings, key signatures, and circle relationships."
+            />
+
+            {/* Circle of Fifths */}
+            <HomeNavCard
+              href="/circle"
+              title="Circle of fifths"
+              badge="Visualization"
+              description="See how keys relate on the circle, view diatonic chords, and preview scales on the piano roll for any key."
+            />
+
+            {/* Progress */}
+            <HomeNavCard
+              href="/progress"
+              title="Progress & stats"
+              badge="Analytics"
+              description="Check accuracy, review load, and recent activity to see how your theory practice is trending over time."
+            />
           </div>
         </section>
       </div>
 
-      {/* Piano Roll Demo Section */}
-      <div className="max-w-7xl mx-auto px-6 py-8">
-        <PianoRollDemo />
+      {/* Piano Roll Demo - wider container */}
+      <div className="max-w-7xl mx-auto px-6 pb-16">
+        <section className="space-y-4">
+          <PianoRollDemo />
+        </section>
       </div>
     </main>
+  );
+}
+
+type HomeNavCardProps = {
+  href: string;
+  title: string;
+  badge: string;
+  description: string;
+};
+
+function HomeNavCard({ href, title, badge, description }: HomeNavCardProps) {
+  return (
+    <Link
+      href={href}
+      className="group block rounded-2xl border border-subtle bg-surface p-5 shadow-sm hover:-translate-y-0.5 hover:shadow-md transition"
+    >
+      <div className="flex items-center justify-between gap-2 mb-3">
+        <h3 className="text-base font-semibold">{title}</h3>
+        <span className="text-[10px] uppercase tracking-wide text-muted border border-subtle rounded-full px-2 py-0.5">
+          {badge}
+        </span>
+      </div>
+      <p className="text-sm text-muted leading-relaxed">{description}</p>
+      <div className="mt-4 text-xs font-medium text-muted group-hover:text-foreground inline-flex items-center gap-1">
+        Open
+        <span aria-hidden="true">↗</span>
+      </div>
+    </Link>
   );
 }
 

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -99,7 +99,7 @@ export default function ProgressPage() {
             Theory practice overview
           </h1>
           <p className="mt-2 text-sm text-muted">
-            Review your flashcard performance and what's coming up in your spaced
+            Review your flashcard performance and what&apos;s coming up in your spaced
             repetition schedule.
           </p>
         </header>

--- a/docs/MilestoneNotes/MILESTONE-8-NOTES.md
+++ b/docs/MilestoneNotes/MILESTONE-8-NOTES.md
@@ -1,0 +1,143 @@
+# Milestone 8 - Home Page Navigation & Learn Path Stub Notes
+
+This document contains summaries from each prompt/task completed during Milestone 8 development.
+
+---
+
+## Prompt 1 - Update Home Page with Navigation Launchpad
+
+### Goal
+Update the home page at `app/page.tsx` to make all core pages discoverable from the home screen while maintaining the Scandinavian minimal hero section.
+
+### Files Modified:
+
+1. **`app/page.tsx`** - Complete home page restructure:
+   - **Removed**: `PianoRollDemo` component (temporarily, later restored)
+   - **Added**: Navigation launchpad section with 4 cards
+   - **Updated**: Hero section styling to match provided design
+   - **Added**: `HomeNavCard` component for navigation cards
+
+### Implementation Details:
+
+**Hero Section:**
+- Updated badge styling with dot indicator
+- Refined typography and spacing
+- Converted buttons to `Link` components pointing to `/practice` and `/circle`
+- Maintained Scandinavian minimal design with semantic tokens
+
+**Launchpad Section:**
+- New navigation grid with 4 cards (2 columns on desktop, stacked on mobile)
+- Cards link to:
+  - `/learn` - Learn path (Curriculum)
+  - `/practice` - Practice cards (Daily SRS)
+  - `/circle` - Circle of fifths (Visualization)
+  - `/progress` - Progress & stats (Analytics)
+- Each card includes:
+  - Title and badge
+  - Description text
+  - Hover effects with subtle lift animation
+  - "Open" link with arrow indicator
+
+**Design System:**
+- Uses semantic Tailwind tokens: `bg-background`, `bg-surface`, `border-subtle`, `text-muted`, etc.
+- Consistent with existing Scandinavian minimal theme
+- Responsive grid layout (md:grid-cols-2)
+
+---
+
+## Prompt 2 - Create `/learn` Stub Page
+
+### Goal
+Create a basic `/learn` page so the "Learn path" card from home doesn't 404, setting the stage for the upcoming Curriculum UI and Milestone system.
+
+### Files Created:
+
+1. **`app/learn/page.tsx`** - New learn page stub:
+   - Simple "coming soon" message
+   - Explains future curriculum hub functionality
+   - Guides users to existing pages (Practice, Circle of fifths, Progress)
+   - Uses semantic design tokens for consistency
+
+### Implementation Details:
+
+**Page Structure:**
+- Minimal layout with centered content
+- "Learn path (coming soon)" heading
+- Description of future curriculum features
+- Helper text pointing to existing functionality
+- Consistent styling with other pages
+
+**Design:**
+- Uses `max-w-4xl` container for readability
+- Semantic tokens: `bg-background`, `text-foreground`, `text-muted`
+- Light typography with proper spacing
+
+---
+
+## Prompt 3 - Quick Sanity Check
+
+### Goal
+Run linting and verify all pages render correctly after the home-page and /learn changes.
+
+### Verification Results:
+
+**Linting:**
+- `npm run lint` passed with no ESLint warnings or errors
+- Both `app/page.tsx` and `app/learn/page.tsx` are clean
+
+**Dev Server Verification:**
+- `/` (Home page) - Hero and navigation grid render correctly
+- `/learn` - Stub page renders without errors
+- `/practice` - Flashcard practice page loads correctly
+- `/circle` - Circle of Fifths visualization works
+- `/progress` - Stats dashboard loads correctly
+
+**Build Status:**
+- Production build passes successfully
+- All routes compile without errors
+
+**Additional Fix:**
+- Fixed pre-existing linting error in `app/progress/page.tsx` (apostrophe in "what's" needed escaping)
+
+---
+
+## Additional Change - Restore Piano Roll Demo
+
+### Goal
+Restore the interactive piano roll demo functionality that was accidentally removed during the home page update.
+
+### Files Modified:
+
+1. **`app/page.tsx`** - Restored PianoRollDemo component:
+   - **Added**: Import for `PianoRollDemo` component
+   - **Added**: New section below launchpad for piano roll demo
+   - **Layout**: Used wider container (`max-w-7xl`) for piano roll demo section
+
+### Implementation Details:
+
+**Piano Roll Demo Features:**
+- Interactive key selection (12 pitch classes)
+- Scale type toggle (Major/Minor)
+- Chord degree selection (I, ii, iii, IV, V, vi, vii°)
+- View mode toggle (Scale notes vs Chord notes)
+- Real-time piano roll visualization updates
+- Uses theory engine for dynamic scale/chord generation
+
+**Layout Structure:**
+- Hero section: `max-w-5xl` container
+- Launchpad section: `max-w-5xl` container
+- Piano Roll Demo: `max-w-7xl` container (wider for controls and visualization)
+
+---
+
+## Summary
+
+This milestone focused on improving home page navigation and discoverability:
+
+1. **Enhanced Home Page**: Added navigation launchpad while maintaining hero section
+2. **New Learn Page**: Created stub page for future curriculum hub
+3. **Restored Functionality**: Brought back interactive piano roll demo
+4. **Quality Assurance**: Verified all pages work correctly and build passes
+
+All changes maintain the Scandinavian minimal design theme and use semantic design tokens throughout. The home page now serves as a clear entry point to all core features of the application.
+


### PR DESCRIPTION
- Updated home page (app/page.tsx) with navigation launchpad
  - Added 4-card grid linking to /learn, /practice, /circle, /progress
  - Refined hero section styling with updated badge and CTAs
  - Maintained Scandinavian minimal design theme
  - Restored PianoRollDemo component below launchpad section

- Created /learn stub page (app/learn/page.tsx)
  - Basic 'coming soon' page for future curriculum hub
  - Guides users to existing functionality
  - Uses semantic design tokens for consistency

- Fixed linting error in app/progress/page.tsx
  - Escaped apostrophe in 'what's' text

- Added milestone documentation (docs/MilestoneNotes/MILESTONE-8-NOTES.md)
  - Detailed summary of all changes and prompts completed

All pages verified working, build passes, no linting errors.

<img width="1389" height="1258" alt="image" src="https://github.com/user-attachments/assets/c39edeb4-2fa9-4abe-bee3-65696f09a9a1" />
