### PR TITLE
Add breadcrumb navigation to app

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
+import { Breadcrumb } from "@/components/navigation/Breadcrumb";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -19,6 +20,7 @@ export default function RootLayout({
         className={`${GeistSans.variable} ${GeistMono.variable} bg-background text-foreground font-sans antialiased min-h-screen`}
       >
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <Breadcrumb />
           {children}
         </div>
       </body>

--- a/components/navigation/Breadcrumb.tsx
+++ b/components/navigation/Breadcrumb.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { usePathname, useParams } from "next/navigation";
+import { ChevronRight, Home } from "lucide-react";
+
+type BreadcrumbItem = {
+  label: string;
+  href: string;
+};
+
+type MilestoneDto = {
+  key: string;
+  title: string;
+};
+
+/**
+ * Get breadcrumb items based on current pathname
+ */
+function getBreadcrumbs(pathname: string, dynamicLabel?: string): BreadcrumbItem[] {
+  const items: BreadcrumbItem[] = [
+    { label: "Home", href: "/" },
+  ];
+
+  // Skip home page
+  if (pathname === "/") {
+    return items;
+  }
+
+  const segments = pathname.split("/").filter(Boolean);
+
+  // Map route segments to friendly names
+  const routeLabels: Record<string, string> = {
+    learn: "Learn",
+    practice: "Practice",
+    circle: "Circle of Fifths",
+    progress: "Progress",
+    dev: "Dev",
+  };
+
+  // Build breadcrumb path
+  let currentPath = "";
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i];
+    currentPath += `/${segment}`;
+
+    // For dynamic routes, use the provided label or fallback to route label
+    const isLast = i === segments.length - 1;
+    let label: string;
+    
+    if (isLast && dynamicLabel) {
+      label = dynamicLabel;
+    } else {
+      label = routeLabels[segment] || segment;
+    }
+
+    items.push({
+      label,
+      href: currentPath,
+    });
+  }
+
+  return items;
+}
+
+export function Breadcrumb() {
+  const pathname = usePathname();
+  const params = useParams();
+  const [dynamicLabel, setDynamicLabel] = useState<string | undefined>();
+
+  // Fetch milestone title for /learn/[key] routes
+  useEffect(() => {
+    if (pathname.startsWith("/learn/") && params.key) {
+      const fetchMilestoneTitle = async () => {
+        try {
+          const res = await fetch("/api/milestones");
+          if (res.ok) {
+            const data: { milestones: MilestoneDto[] } = await res.json();
+            const milestone = data.milestones.find(
+              (m) => m.key === params.key
+            );
+            if (milestone) {
+              setDynamicLabel(milestone.title);
+            }
+          }
+        } catch (err) {
+          // Silently fail - will use fallback label
+          console.error("Error fetching milestone title:", err);
+        }
+      };
+      void fetchMilestoneTitle();
+    }
+  }, [pathname, params.key]);
+
+  const items = getBreadcrumbs(pathname, dynamicLabel);
+
+  // Don't show breadcrumb on home page
+  if (pathname === "/" || items.length <= 1) {
+    return null;
+  }
+
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className="mb-6 flex items-center gap-1.5 text-xs text-muted"
+    >
+      {items.map((item, index) => {
+        const isLast = index === items.length - 1;
+
+        return (
+          <div key={item.href} className="flex items-center gap-1.5">
+            {index === 0 ? (
+              <Link
+                href={item.href}
+                className="inline-flex items-center gap-1 hover:text-foreground transition-colors"
+                aria-label="Home"
+              >
+                <Home className="w-3.5 h-3.5" />
+                <span className="sr-only">{item.label}</span>
+              </Link>
+            ) : (
+              <>
+                <ChevronRight className="w-3 h-3 text-muted/50" />
+                {isLast ? (
+                  <span className="text-foreground font-medium">
+                    {item.label}
+                  </span>
+                ) : (
+                  <Link
+                    href={item.href}
+                    className="hover:text-foreground transition-colors"
+                  >
+                    {item.label}
+                  </Link>
+                )}
+              </>
+            )}
+          </div>
+        );
+      })}
+    </nav>
+  );
+}
+

--- a/docs/MilestoneNotes/NAVIGATION-QUICK-FIX-NOTES.md
+++ b/docs/MilestoneNotes/NAVIGATION-QUICK-FIX-NOTES.md
@@ -1,0 +1,86 @@
+# Navigation Quick Fix - Breadcrumb Navigation
+
+This document contains the summary of the breadcrumb navigation implementation.
+
+---
+
+## Goal
+
+Add breadcrumb navigation to help users move around the app and understand their current location.
+
+---
+
+## Implementation
+
+### Files Created
+
+1. **`components/navigation/Breadcrumb.tsx`** - New breadcrumb component:
+   - Client component using Next.js `usePathname` and `useParams` hooks
+   - Automatically generates breadcrumb trail based on current route
+   - Fetches milestone titles for dynamic `/learn/[key]` routes
+   - Home icon link (always visible except on home page)
+   - Clickable intermediate links, non-clickable current page
+   - Hidden on home page
+
+### Files Modified
+
+1. **`app/layout.tsx`** - Added Breadcrumb component:
+   - Integrated into root layout
+   - Appears on all pages (except home)
+   - Positioned at top of content area
+
+---
+
+## Features
+
+### Route Mapping
+
+- `/learn` → "Learn"
+- `/practice` → "Practice"
+- `/circle` → "Circle of Fifths"
+- `/progress` → "Progress"
+- `/learn/[key]` → Fetches milestone title dynamically
+
+### Behavior
+
+- **Home page**: Breadcrumb hidden
+- **Top-level pages**: Shows "Home > [Page Name]"
+- **Nested pages**: Shows "Home > [Parent] > [Current]"
+- **Dynamic routes**: Fetches actual milestone title from API
+- **Fallback**: Uses route key if API call fails
+
+### Styling
+
+- Uses existing design tokens (text-muted, text-foreground, etc.)
+- Small text size (text-xs) for subtle appearance
+- Hover effects on clickable links
+- ChevronRight separators between items
+- Home icon for first item
+- Current page shown in bold (non-clickable)
+
+---
+
+## User Experience
+
+Users can now:
+- See their current location in the app hierarchy
+- Navigate back to parent pages via breadcrumb links
+- Quickly return to home via home icon
+- Understand the relationship between pages (e.g., Learn > Foundation)
+
+---
+
+## Technical Details
+
+- Client component (uses React hooks)
+- Fetches milestone data for dynamic routes
+- Gracefully handles API failures
+- Accessible with ARIA labels
+- Responsive design
+
+---
+
+## Summary
+
+Breadcrumb navigation has been successfully added to the app, providing users with clear navigation context and easy access to parent pages. The implementation is lightweight, accessible, and integrates seamlessly with the existing design system.
+


### PR DESCRIPTION
Implement breadcrumb navigation component to help users navigate and understand their location within the app.

## Implementation

### New Component
- Created components/navigation/Breadcrumb.tsx
  - Client component using Next.js navigation hooks
  - Automatically generates breadcrumb trail from current route
  - Fetches milestone titles for dynamic /learn/[key] routes
  - Home icon link for quick navigation
  - Clickable intermediate links, non-clickable current page
  - Hidden on home page

### Layout Integration
- Updated app/layout.tsx to include Breadcrumb component
  - Appears on all pages (except home)
  - Positioned at top of content area

## Features

### Route Mapping
- Maps routes to friendly names (Learn, Practice, Circle of Fifths, Progress)
- Fetches dynamic milestone titles from API
- Graceful fallback if API call fails

### User Experience
- Clear visual hierarchy showing current location
- Easy navigation back to parent pages
- Quick return to home via home icon
- Understands page relationships (e.g., Learn > Foundation)

### Design
- Uses existing design tokens for consistency
- Subtle appearance (small text, muted colors)
- Hover effects on clickable links
- Chevron separators between items
- Accessible with ARIA labels

## Files Modified

- components/navigation/Breadcrumb.tsx (new)
- app/layout.tsx
- docs/MilestoneNotes/NAVIGATION-QUICK-FIX-NOTES.md (new)

## Impact

Users can now:
- See their current location in the app
- Navigate back to parent pages easily
- Quickly return to home
- Better understand the app structure