### PR TITLE
Add natural, humanized chord playback with settings panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Generate musically coherent chord progressions in any key and mode. Refine them 
 - **4 complexity levels** — Simple triads through altered dominants, tritone substitutions, and passing chords
 - **Variable-duration chords** — Full, half, quarter, and eighth-note durations assigned contextually
 - **Multiple sound presets** — Salamander Grand Piano, Casio Electric Piano (with chorus), and FM Organ via Tone.js
+- **Natural, humanized playback** — Chords are played note-by-note with subtle per-note velocity and timing variation (±~12 ms) so progressions feel hand-played rather than software-triggered. Configurable via the **Audio** menu:
+  - **Velocity** — base chord loudness, 20–100% (default 70%)
+  - **Humanize** — amount of velocity + timing variation, Off → Natural (default 50%); at 0% playback is perfectly quantized for reference
+  - **Sustain** — *Natural* lets notes ring slightly, *Off* tightens releases for clarity
+  - **Soft Strum** — optional articulation that lightly rolls chord notes in (~18 ms apart), like a pianist easing into a chord; disabled by default
+  - All playback settings persist across sessions via localStorage
 - **Interactive piano roll** — Click notes to preview, select and shift individual notes up/down by octave
 - **Chord locking** — Lock specific chords to preserve them while regenerating the rest
 - **MIDI export** — Download your progression as a standard MIDI file
@@ -64,6 +70,12 @@ Open [http://localhost:3000](http://localhost:3000) to start generating progress
 - [Framer Motion](https://motion.dev) — Animations
 - TypeScript
 
+### Audio architecture & performance
+
+Instruments are defined in a small registry (`lib/audio/synthPresets.ts`) so new instruments (Strings, Pad, …) can be added as a single entry without touching playback code. Playback humanization is a pure, dependency-free module (`lib/audio/humanization.ts`) that the scheduler applies per note.
+
+The piano and electric piano are **sampled** (Salamander Grand / Casio) and stream from the Tone.js CDN — humanization adds **no bundle or asset weight**, no new downloads, and negligible CPU. A "Loading Piano…" state covers the brief sample preload on first selection. (Note: the Salamander set is single-velocity, so velocity changes loudness rather than timbre — a deliberate trade for fast load, small footprint, and mobile/browser compatibility.)
+
 ## Usage
 
 ### Chord Progression Generator
@@ -77,7 +89,7 @@ Open [http://localhost:3000](http://localhost:3000) to start generating progress
 7. **Export MIDI** to bring your progression into a DAW
 8. Click the **substitute icon** on a chord card to browse theory-guided replacement options
 9. **Double-click** the piano roll grid to add or remove individual notes — chord labels update automatically
-10. Click **Melody** to generate a melody line — choose a style (Lyrical, Rhythmic, Arpeggio) and click **Melody** again for a new line. Use the **Audio** button in the action bar to mute or unmute chords and melody
+10. Click **Melody** to generate a melody line — choose a style (Lyrical, Rhythmic, Arpeggio) and click **Melody** again for a new line. Use the **Audio** button in the action bar to mute/unmute chords and melody and to adjust playback feel — **Velocity**, **Humanize**, **Sustain**, and **Soft Strum** vs **Block Chord**
 11. Click **Save** to bookmark a progression to your favorites. Click **Favorites** to view, load, or remove saved progressions
 
 ### Harmonic Sketchpad

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,12 @@ import { motion, AnimatePresence } from "framer-motion";
 import { Play, Square, Download, Sparkles, Music, Lock, Unlock, LayoutDashboard, Shuffle, RotateCcw, ChevronDown, Heart, Trash2, Upload, VolumeX, Volume2, Settings2, Layers, Save, MoreVertical } from "lucide-react";
 import Link from "next/link";
 import { useProgressionStore, COMPLEXITY_LABELS, type ComplexityLevel } from "@/lib/state/progressionStore";
+import {
+  usePlaybackSettingsStore,
+  CHORD_VELOCITY_MIN,
+  CHORD_VELOCITY_MAX,
+} from "@/lib/state/playbackSettingsStore";
+import { buildChordEvents, humanizeVelocity } from "@/lib/audio/humanization";
 import { InteractivePianoRoll } from "@/components/creative/InteractivePianoRoll";
 import { SubstitutionPanel } from "@/components/creative/SubstitutionPanel";
 import { VoicingFeedback } from "@/components/feedback/VoicingFeedback";
@@ -113,6 +119,17 @@ export default function HarmoniaPage() {
 
   const { favorites, addFavorite, removeFavorite } = useFavoritesStore();
 
+  const {
+    chordVelocity,
+    humanize,
+    sustainMode,
+    playbackStyle,
+    setChordVelocity,
+    setHumanize,
+    setSustainMode,
+    setPlaybackStyle,
+  } = usePlaybackSettingsStore();
+
   const [playbackIndex, setPlaybackIndex] = useState<number | null>(null);
   const [soundPreset, setSoundPreset] = useState<SoundPresetId>("piano");
   const [generationKey, setGenerationKey] = useState(0);
@@ -125,6 +142,8 @@ export default function HarmoniaPage() {
   const [settingsExpanded, setSettingsExpanded] = useState(false);
   const [showMelodyOnRoll, setShowMelodyOnRoll] = useState(true);
 
+  const presetLabel = SOUND_PRESETS.find((p) => p.id === soundPreset)?.label ?? "Instrument";
+
   const synthRef = useRef<Synth | null>(null);
   const melodySynthRef = useRef<MelodySynth | null>(null);
   const playbackIndexRef = useRef(0);
@@ -135,8 +154,9 @@ export default function HarmoniaPage() {
 
   useEffect(() => {
     setIsSynthLoading(presetNeedsLoading(soundPreset));
-    const synth = createSynthForPreset(soundPreset, () => {
-      setIsSynthLoading(false);
+    const synth = createSynthForPreset(soundPreset, {
+      sustainMode,
+      onLoaded: () => setIsSynthLoading(false),
     });
     synthRef.current = synth;
 
@@ -145,7 +165,7 @@ export default function HarmoniaPage() {
       synth.dispose();
       synthRef.current = null;
     };
-  }, [soundPreset]);
+  }, [soundPreset, sustainMode]);
 
   /* ─── Melody synth lifecycle ─── */
 
@@ -245,7 +265,21 @@ export default function HarmoniaPage() {
             chord.notesWithOctave && chord.notesWithOctave.length > 0
               ? chord.notesWithOctave
               : chord.notes.map((n) => `${n}3`);
-          synthRef.current.triggerAttackRelease(notes, duration, time);
+          // Read live settings so velocity/humanize/style changes apply mid-loop.
+          const ps = usePlaybackSettingsStore.getState();
+          const events = buildChordEvents(notes, {
+            baseVelocity: ps.chordVelocity,
+            humanize: ps.humanize,
+            style: ps.playbackStyle,
+          });
+          for (const ev of events) {
+            synthRef.current.triggerAttackRelease(
+              ev.note,
+              duration,
+              time + ev.timeOffset,
+              ev.velocity,
+            );
+          }
         }
 
         Tone.getDraw().schedule(() => {
@@ -269,7 +303,9 @@ export default function HarmoniaPage() {
 
         const mid = Tone.getTransport().schedule((time) => {
           if (useProgressionStore.getState().melodyEnabled) {
-            melodySynthRef.current?.triggerAttackRelease(mn.noteWithOctave, mDuration, time);
+            const ps = usePlaybackSettingsStore.getState();
+            const velocity = humanizeVelocity(ps.chordVelocity, ps.humanize);
+            melodySynthRef.current?.triggerAttackRelease(mn.noteWithOctave, mDuration, time, velocity);
           }
         }, mTimeStr);
         ids.push(mid);
@@ -360,10 +396,29 @@ export default function HarmoniaPage() {
     addFavorite({ name, progression: currentProgression, rootKey, mode, complexity, bpm });
   }, [currentProgression, rootKey, mode, complexity, bpm, addFavorite]);
 
+  /**
+   * Play a one-off chord preview with humanized per-note velocity (no strum,
+   * so previews stay snappy). Reads live settings via getState.
+   */
+  const playChordPreview = useCallback((notesWithOctave: string[], duration: string) => {
+    if (!synthRef.current) return;
+    const ps = usePlaybackSettingsStore.getState();
+    const events = buildChordEvents(notesWithOctave, {
+      baseVelocity: ps.chordVelocity,
+      humanize: ps.humanize,
+      style: "block",
+    });
+    for (const ev of events) {
+      synthRef.current.triggerAttackRelease(ev.note, duration, undefined, ev.velocity);
+    }
+  }, []);
+
   const handlePlayNote = useCallback(
     (noteWithOctave: string) => {
       if (synthRef.current) {
-        synthRef.current.triggerAttackRelease(noteWithOctave, "4n");
+        const ps = usePlaybackSettingsStore.getState();
+        const velocity = humanizeVelocity(ps.chordVelocity, ps.humanize);
+        synthRef.current.triggerAttackRelease(noteWithOctave, "4n", undefined, velocity);
       }
     },
     []
@@ -379,7 +434,7 @@ export default function HarmoniaPage() {
         synthRef.current.releaseAll();
         // Small delay to let releaseAll take effect before new attack
         setTimeout(() => {
-          synthRef.current?.triggerAttackRelease(notesWithOctave, "2n");
+          playChordPreview(notesWithOctave, "2n");
         }, 10);
       }
       // Set this chord as the new loop start position and select it
@@ -387,7 +442,7 @@ export default function HarmoniaPage() {
       setPlaybackIndex(chordIndex);
       setSelectedChordIndex(chordIndex);
     },
-    [isPlaying, setIsPlaying]
+    [isPlaying, setIsPlaying, playChordPreview]
   );
 
   // ─── Substitution handlers ───
@@ -396,11 +451,11 @@ export default function HarmoniaPage() {
       if (synthRef.current) {
         synthRef.current.releaseAll();
         setTimeout(() => {
-          synthRef.current?.triggerAttackRelease(option.candidateNotesWithOctave, "2n");
+          playChordPreview(option.candidateNotesWithOctave, "2n");
         }, 10);
       }
     },
-    []
+    [playChordPreview]
   );
 
   const handleSubstitutionApply = useCallback(
@@ -411,11 +466,11 @@ export default function HarmoniaPage() {
       if (synthRef.current) {
         synthRef.current.releaseAll();
         setTimeout(() => {
-          synthRef.current?.triggerAttackRelease(option.candidateNotesWithOctave, "2n");
+          playChordPreview(option.candidateNotesWithOctave, "2n");
         }, 10);
       }
     },
-    [substitutionTarget, applySubstitution]
+    [substitutionTarget, applySubstitution, playChordPreview]
   );
 
   const handleSubstitutionRevert = useCallback(() => {
@@ -822,7 +877,7 @@ export default function HarmoniaPage() {
               {isSynthLoading ? (
                 <>
                   <span className="w-3.5 h-3.5 border-2 border-current border-t-transparent rounded-full animate-spin" />
-                  Loading
+                  Loading {presetLabel}…
                 </>
               ) : isPlaying ? (
                 <>
@@ -888,7 +943,7 @@ export default function HarmoniaPage() {
               {audioMenuOpen && (
                 <>
                   <div className="fixed inset-0 z-40" onClick={() => setAudioMenuOpen(false)} />
-                  <div className="absolute top-full right-0 mt-2 z-50 w-44 rounded-2xl border border-border-subtle bg-surface shadow-xl p-1.5 flex flex-col gap-0.5">
+                  <div className="absolute top-full right-0 mt-2 z-50 w-72 max-w-[calc(100vw-2rem)] rounded-2xl border border-border-subtle bg-surface shadow-xl p-1.5 flex flex-col gap-0.5">
                     <button
                       onClick={() => setChordsEnabled(!chordsEnabled)}
                       className="flex items-center justify-between gap-2 w-full px-3 py-2 rounded-xl text-sm font-medium text-foreground hover:bg-surface-muted transition-colors"
@@ -914,6 +969,95 @@ export default function HarmoniaPage() {
                         {!melody ? "None" : melodyEnabled ? "On" : "Muted"}
                       </span>
                     </button>
+
+                    {/* ── Playback settings ── */}
+                    <div className="my-1 h-px bg-border-subtle" />
+                    <span className="px-3 pt-1 pb-0.5 text-[10px] font-bold uppercase tracking-widest text-muted">
+                      Playback
+                    </span>
+
+                    {/* Chord Velocity */}
+                    <div className="px-3 py-1.5 flex flex-col gap-1">
+                      <div className="flex items-center justify-between text-xs font-medium text-foreground">
+                        <span>Velocity</span>
+                        <span className="text-muted tabular-nums">{Math.round(chordVelocity * 100)}%</span>
+                      </div>
+                      <input
+                        type="range"
+                        min={CHORD_VELOCITY_MIN}
+                        max={CHORD_VELOCITY_MAX}
+                        step={0.01}
+                        value={chordVelocity}
+                        onChange={(e) => setChordVelocity(Number(e.target.value))}
+                        className="w-full accent-accent cursor-pointer"
+                        aria-label="Chord velocity"
+                      />
+                      <div className="flex justify-between text-[9px] uppercase tracking-wide text-muted/60">
+                        <span>Soft</span>
+                        <span>Loud</span>
+                      </div>
+                    </div>
+
+                    {/* Humanization */}
+                    <div className="px-3 py-1.5 flex flex-col gap-1">
+                      <div className="flex items-center justify-between text-xs font-medium text-foreground">
+                        <span>Humanize</span>
+                        <span className="text-muted tabular-nums">{Math.round(humanize * 100)}%</span>
+                      </div>
+                      <input
+                        type="range"
+                        min={0}
+                        max={1}
+                        step={0.25}
+                        value={humanize}
+                        onChange={(e) => setHumanize(Number(e.target.value))}
+                        className="w-full accent-accent cursor-pointer"
+                        aria-label="Humanization amount"
+                      />
+                      <div className="flex justify-between text-[9px] uppercase tracking-wide text-muted/60">
+                        <span>Off</span>
+                        <span>Natural</span>
+                      </div>
+                    </div>
+
+                    {/* Sustain */}
+                    <div className="px-3 py-1.5 flex items-center justify-between gap-2">
+                      <span className="text-xs font-medium text-foreground">Sustain</span>
+                      <div className="flex items-center rounded-lg bg-background/60 border border-border-subtle p-0.5">
+                        {(["off", "natural"] as const).map((m) => (
+                          <button
+                            key={m}
+                            onClick={() => setSustainMode(m)}
+                            className={`px-2.5 py-1 rounded-md text-[11px] font-medium capitalize transition-colors ${
+                              sustainMode === m ? "bg-accent text-white shadow-sm" : "text-muted hover:text-foreground"
+                            }`}
+                          >
+                            {m}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+
+                    {/* Playback Style */}
+                    <div className="px-3 py-1.5 flex items-center justify-between gap-2">
+                      <span className="text-xs font-medium text-foreground">Style</span>
+                      <div className="flex items-center rounded-lg bg-background/60 border border-border-subtle p-0.5">
+                        {([
+                          { value: "block", label: "Block" },
+                          { value: "strum", label: "Soft Strum" },
+                        ] as const).map((s) => (
+                          <button
+                            key={s.value}
+                            onClick={() => setPlaybackStyle(s.value)}
+                            className={`px-2.5 py-1 rounded-md text-[11px] font-medium transition-colors ${
+                              playbackStyle === s.value ? "bg-accent text-white shadow-sm" : "text-muted hover:text-foreground"
+                            }`}
+                          >
+                            {s.label}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
                   </div>
                 </>
               )}

--- a/components/sketchpad/Workspace.tsx
+++ b/components/sketchpad/Workspace.tsx
@@ -54,7 +54,7 @@ export function SketchpadWorkspace({ project }: { project: HarmonicSketchProject
   // Synth lifecycle
   useEffect(() => {
     setIsSynthLoading(presetNeedsLoading(soundPreset));
-    const synth = createSynthForPreset(soundPreset, () => setIsSynthLoading(false));
+    const synth = createSynthForPreset(soundPreset, { onLoaded: () => setIsSynthLoading(false) });
     synthRef.current = synth;
     return () => {
       synth.releaseAll();

--- a/lib/audio/humanization.ts
+++ b/lib/audio/humanization.ts
@@ -1,0 +1,94 @@
+/**
+ * Playback Humanization Engine
+ *
+ * Pure helpers that turn a set of chord notes into per-note playback events
+ * with subtle velocity and timing variation, so generated progressions feel
+ * hand-played rather than software-triggered.
+ *
+ * Intentionally free of any Tone.js dependency — it returns plain data that
+ * the scheduler applies. This keeps the logic easy to reason about and reuse.
+ */
+
+/** How notes within a chord are articulated. */
+export type PlaybackStyle = "block" | "strum";
+
+/** How long notes are allowed to ring after release. */
+export type SustainMode = "off" | "natural";
+
+/** A single note ready to be scheduled. */
+export interface NoteEvent {
+  /** Note name with octave, e.g. "C4". */
+  note: string;
+  /** Playback velocity in the range 0–1. */
+  velocity: number;
+  /** Timing offset in seconds, relative to the chord's scheduled time. */
+  timeOffset: number;
+}
+
+export interface HumanizeOptions {
+  /** Base velocity (0–1) before any humanization. */
+  baseVelocity: number;
+  /** Humanization amount (0 = off, 1 = full natural variation). */
+  humanize: number;
+  /** Articulation style. Strum only applies to multi-note chords. */
+  style?: PlaybackStyle;
+}
+
+/* ─── Tuning constants ─── */
+
+/** Maximum +/- velocity swing at full humanization. Small, musical. */
+const MAX_VELOCITY_VARIATION = 0.12;
+/** Maximum +/- timing jitter at full humanization, in seconds (±12 ms). */
+const MAX_TIMING_JITTER = 0.012;
+/** Per-note delay between strummed notes, in seconds (~18 ms). */
+const STRUM_STEP = 0.018;
+/** Velocity floor/ceiling so notes are always audible and never clip. */
+const MIN_VELOCITY = 0.15;
+const MAX_VELOCITY = 1;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/** Symmetric random value in [-1, 1]. */
+function bipolarRandom(): number {
+  return Math.random() * 2 - 1;
+}
+
+/**
+ * Compute a single humanized velocity from a base velocity and amount.
+ * Used for both chords and melody so dynamics stay consistent.
+ */
+export function humanizeVelocity(baseVelocity: number, humanize: number): number {
+  const variation = bipolarRandom() * MAX_VELOCITY_VARIATION * humanize;
+  return clamp(baseVelocity + variation, MIN_VELOCITY, MAX_VELOCITY);
+}
+
+/**
+ * Build per-note playback events for a chord, applying velocity variation,
+ * timing jitter, and (optionally) a soft strum.
+ *
+ * The result preserves musical balance: variation is small and bounded, and
+ * with `humanize === 0` and `style === "block"` every note is identical with a
+ * zero offset — i.e. the original mechanical behaviour, for regression safety.
+ */
+export function buildChordEvents(
+  notes: string[],
+  { baseVelocity, humanize, style = "block" }: HumanizeOptions,
+): NoteEvent[] {
+  const useStrum = style === "strum" && notes.length > 1;
+
+  return notes.map((note, index) => {
+    const jitter = bipolarRandom() * MAX_TIMING_JITTER * humanize;
+    const strumOffset = useStrum ? index * STRUM_STEP : 0;
+
+    return {
+      note,
+      velocity: humanizeVelocity(baseVelocity, humanize),
+      // Strum offsets are always >= 0; jitter is symmetric around the beat.
+      // The scheduler fires ahead of the event time, so small negative
+      // offsets stay safely in the future.
+      timeOffset: strumOffset + jitter,
+    };
+  });
+}

--- a/lib/audio/synthPresets.ts
+++ b/lib/audio/synthPresets.ts
@@ -1,11 +1,14 @@
 /**
  * Shared Synth Presets & Effects Chain
  *
- * Centralised audio setup used by both the main progression page
- * and the Sketchpad workspace.
+ * Centralised audio setup used by the main progression page (and available to
+ * the Sketchpad workspace). Instruments are described by a small registry so
+ * new instruments (Strings, Pad, …) can be added as a single entry without
+ * touching call sites.
  */
 
 import * as Tone from "tone";
+import type { SustainMode } from "./humanization";
 
 /* ─── Types ─── */
 
@@ -13,11 +16,43 @@ export type SoundPresetId = "piano" | "electric-piano" | "organ";
 export type Synth = Tone.PolySynth | Tone.Sampler;
 export type MelodySynth = Tone.Synth | Tone.FMSynth | Tone.Sampler;
 
-export const SOUND_PRESETS: ReadonlyArray<{ id: SoundPresetId; label: string }> = [
-  { id: "piano", label: "Piano" },
-  { id: "electric-piano", label: "Electric Piano" },
-  { id: "organ", label: "Organ" },
-];
+/** Options passed when building a chord instrument. */
+export interface CreateSynthOptions {
+  /** Controls how long notes ring after release. Defaults to "natural". */
+  sustainMode?: SustainMode;
+  /** Called once the instrument is ready (immediately for synths). */
+  onLoaded?: () => void;
+}
+
+/** Options passed when building a melody instrument. */
+export interface CreateMelodySynthOptions {
+  onLoaded?: () => void;
+}
+
+/**
+ * A self-contained description of a playable instrument. Adding a new
+ * instrument means adding one entry to {@link INSTRUMENTS} — call sites stay
+ * unchanged.
+ */
+export interface InstrumentDefinition {
+  id: SoundPresetId;
+  label: string;
+  category: "keys" | "synth";
+  /** Whether the instrument downloads samples (show a loading state). */
+  needsLoading: boolean;
+  create: (opts: CreateSynthOptions) => Synth;
+  createMelody: (opts: CreateMelodySynthOptions) => MelodySynth;
+}
+
+/* ─── Release tuning ─── */
+
+/** Map a sustain mode to a release time (seconds) for a given instrument. */
+function pianoRelease(mode: SustainMode | undefined): number {
+  return mode === "off" ? 0.25 : 1;
+}
+function epRelease(mode: SustainMode | undefined): number {
+  return mode === "off" ? 0.2 : 0.8;
+}
 
 /* ─── Effects Chain (lazy singletons) ─── */
 
@@ -67,82 +102,90 @@ function getEPChorus(): Tone.Chorus {
   return epChorusNode;
 }
 
-/* ─── Preset Factory ─── */
+/* ─── Sample maps (shared between chord & melody samplers) ─── */
 
-export function createSynthForPreset(
-  preset: SoundPresetId,
-  onLoaded?: () => void,
-): Synth {
-  const { compressor } = getEffectsChain();
+const SALAMANDER_URLS = {
+  A1: "A1.mp3", A2: "A2.mp3", A3: "A3.mp3", A4: "A4.mp3", A5: "A5.mp3",
+  C2: "C2.mp3", C3: "C3.mp3", C4: "C4.mp3", C5: "C5.mp3", C6: "C6.mp3",
+  "D#2": "Ds2.mp3", "D#3": "Ds3.mp3", "D#4": "Ds4.mp3", "D#5": "Ds5.mp3",
+  "F#2": "Fs2.mp3", "F#3": "Fs3.mp3", "F#4": "Fs4.mp3", "F#5": "Fs5.mp3",
+} as const;
 
-  switch (preset) {
-    /* ── Piano: Salamander Grand Piano samples ── */
-    case "piano": {
+/* ─── Instrument Registry ─── */
+
+export const INSTRUMENTS: Record<SoundPresetId, InstrumentDefinition> = {
+  /* ── Piano: Salamander Grand Piano samples ── */
+  piano: {
+    id: "piano",
+    label: "Piano",
+    category: "keys",
+    needsLoading: true,
+    create: ({ sustainMode, onLoaded }) => {
+      const { compressor } = getEffectsChain();
       const sampler = new Tone.Sampler({
-        urls: {
-          A1: "A1.mp3",
-          A2: "A2.mp3",
-          A3: "A3.mp3",
-          A4: "A4.mp3",
-          A5: "A5.mp3",
-          C2: "C2.mp3",
-          C3: "C3.mp3",
-          C4: "C4.mp3",
-          C5: "C5.mp3",
-          C6: "C6.mp3",
-          "D#2": "Ds2.mp3",
-          "D#3": "Ds3.mp3",
-          "D#4": "Ds4.mp3",
-          "D#5": "Ds5.mp3",
-          "F#2": "Fs2.mp3",
-          "F#3": "Fs3.mp3",
-          "F#4": "Fs4.mp3",
-          "F#5": "Fs5.mp3",
-        },
+        urls: SALAMANDER_URLS,
         baseUrl: "https://tonejs.github.io/audio/salamander/",
-        release: 1,
+        release: pianoRelease(sustainMode),
         volume: -6,
         onload: () => onLoaded?.(),
       });
       sampler.connect(compressor);
       sampler.connect(getPianoReverb());
       return sampler;
-    }
-
-    /* ── Electric Piano: Casio samples ── */
-    case "electric-piano": {
+    },
+    createMelody: ({ onLoaded }) => {
+      const { compressor } = getEffectsChain();
       const sampler = new Tone.Sampler({
-        urls: {
-          A1: "A1.mp3",
-          A2: "A2.mp3",
-          A3: "A3.mp3",
-          A4: "A4.mp3",
-          A5: "A5.mp3",
-          C2: "C2.mp3",
-          C3: "C3.mp3",
-          C4: "C4.mp3",
-          C5: "C5.mp3",
-          C6: "C6.mp3",
-          "D#2": "Ds2.mp3",
-          "D#3": "Ds3.mp3",
-          "D#4": "Ds4.mp3",
-          "D#5": "Ds5.mp3",
-          "F#2": "Fs2.mp3",
-          "F#3": "Fs3.mp3",
-          "F#4": "Fs4.mp3",
-          "F#5": "Fs5.mp3",
-        },
+        urls: SALAMANDER_URLS,
+        baseUrl: "https://tonejs.github.io/audio/salamander/",
+        release: 1,
+        volume: -4,
+        onload: () => onLoaded?.(),
+      });
+      sampler.connect(compressor);
+      sampler.connect(getPianoReverb());
+      return sampler;
+    },
+  },
+
+  /* ── Electric Piano: Casio samples ── */
+  "electric-piano": {
+    id: "electric-piano",
+    label: "Electric Piano",
+    category: "keys",
+    needsLoading: true,
+    create: ({ sustainMode, onLoaded }) => {
+      const sampler = new Tone.Sampler({
+        urls: SALAMANDER_URLS,
         baseUrl: "https://tonejs.github.io/audio/casio/",
-        release: 0.8,
+        release: epRelease(sustainMode),
         volume: -8,
         onload: () => onLoaded?.(),
       });
       sampler.connect(getEPChorus());
       return sampler;
-    }
+    },
+    createMelody: ({ onLoaded }) => {
+      const sampler = new Tone.Sampler({
+        urls: SALAMANDER_URLS,
+        baseUrl: "https://tonejs.github.io/audio/casio/",
+        release: 0.8,
+        volume: -6,
+        onload: () => onLoaded?.(),
+      });
+      sampler.connect(getEPChorus());
+      return sampler;
+    },
+  },
 
-    /* ── Organ: FM synthesis with drawbar-style harmonics ── */
-    case "organ": {
+  /* ── Organ: FM synthesis with drawbar-style harmonics ── */
+  organ: {
+    id: "organ",
+    label: "Organ",
+    category: "synth",
+    needsLoading: false,
+    create: ({ onLoaded }) => {
+      const { compressor } = getEffectsChain();
       onLoaded?.();
       return new Tone.PolySynth(Tone.FMSynth, {
         volume: -14,
@@ -153,66 +196,9 @@ export function createSynthForPreset(
         envelope: { attack: 0.04, decay: 0.1, sustain: 0.9, release: 0.3 },
         modulationEnvelope: { attack: 0.02, decay: 0.1, sustain: 0.8, release: 0.3 },
       }).connect(compressor);
-    }
-
-    default: {
-      onLoaded?.();
-      return new Tone.PolySynth(Tone.Synth, {
-        volume: -14,
-        oscillator: { type: "triangle" },
-        envelope: { attack: 0.06, decay: 0.2, sustain: 0.6, release: 0.8 },
-      }).connect(compressor);
-    }
-  }
-}
-
-/**
- * Create a melody synth that matches the given preset timbre.
- * Uses the same samples/synthesis as chords but configured for monophonic melody.
- */
-export function createMelodySynthForPreset(
-  preset: SoundPresetId,
-  onLoaded?: () => void,
-): MelodySynth {
-  const { compressor } = getEffectsChain();
-
-  switch (preset) {
-    case "piano": {
-      const sampler = new Tone.Sampler({
-        urls: {
-          A1: "A1.mp3", A2: "A2.mp3", A3: "A3.mp3", A4: "A4.mp3", A5: "A5.mp3",
-          C2: "C2.mp3", C3: "C3.mp3", C4: "C4.mp3", C5: "C5.mp3", C6: "C6.mp3",
-          "D#2": "Ds2.mp3", "D#3": "Ds3.mp3", "D#4": "Ds4.mp3", "D#5": "Ds5.mp3",
-          "F#2": "Fs2.mp3", "F#3": "Fs3.mp3", "F#4": "Fs4.mp3", "F#5": "Fs5.mp3",
-        },
-        baseUrl: "https://tonejs.github.io/audio/salamander/",
-        release: 1,
-        volume: -4,
-        onload: () => onLoaded?.(),
-      });
-      sampler.connect(compressor);
-      sampler.connect(getPianoReverb());
-      return sampler;
-    }
-
-    case "electric-piano": {
-      const sampler = new Tone.Sampler({
-        urls: {
-          A1: "A1.mp3", A2: "A2.mp3", A3: "A3.mp3", A4: "A4.mp3", A5: "A5.mp3",
-          C2: "C2.mp3", C3: "C3.mp3", C4: "C4.mp3", C5: "C5.mp3", C6: "C6.mp3",
-          "D#2": "Ds2.mp3", "D#3": "Ds3.mp3", "D#4": "Ds4.mp3", "D#5": "Ds5.mp3",
-          "F#2": "Fs2.mp3", "F#3": "Fs3.mp3", "F#4": "Fs4.mp3", "F#5": "Fs5.mp3",
-        },
-        baseUrl: "https://tonejs.github.io/audio/casio/",
-        release: 0.8,
-        volume: -6,
-        onload: () => onLoaded?.(),
-      });
-      sampler.connect(getEPChorus());
-      return sampler;
-    }
-
-    case "organ": {
+    },
+    createMelody: ({ onLoaded }) => {
+      const { compressor } = getEffectsChain();
       onLoaded?.();
       return new Tone.FMSynth({
         volume: -12,
@@ -223,17 +209,32 @@ export function createMelodySynthForPreset(
         envelope: { attack: 0.04, decay: 0.1, sustain: 0.9, release: 0.3 },
         modulationEnvelope: { attack: 0.02, decay: 0.1, sustain: 0.8, release: 0.3 },
       }).connect(compressor);
-    }
+    },
+  },
+};
 
-    default: {
-      onLoaded?.();
-      return new Tone.Synth({
-        volume: -12,
-        oscillator: { type: "triangle" },
-        envelope: { attack: 0.06, decay: 0.2, sustain: 0.6, release: 0.8 },
-      }).connect(compressor);
-    }
-  }
+/** Ordered list of selectable instruments (for UI menus). */
+export const SOUND_PRESETS: ReadonlyArray<{ id: SoundPresetId; label: string }> =
+  Object.values(INSTRUMENTS).map(({ id, label }) => ({ id, label }));
+
+/* ─── Public factory API (thin lookups over the registry) ─── */
+
+function resolveInstrument(preset: SoundPresetId): InstrumentDefinition {
+  return INSTRUMENTS[preset] ?? INSTRUMENTS.piano;
+}
+
+export function createSynthForPreset(
+  preset: SoundPresetId,
+  opts: CreateSynthOptions = {},
+): Synth {
+  return resolveInstrument(preset).create(opts);
+}
+
+export function createMelodySynthForPreset(
+  preset: SoundPresetId,
+  opts: CreateMelodySynthOptions = {},
+): MelodySynth {
+  return resolveInstrument(preset).createMelody(opts);
 }
 
 /**
@@ -241,5 +242,5 @@ export function createMelodySynthForPreset(
  * Useful for showing a loading spinner while samples download.
  */
 export function presetNeedsLoading(preset: SoundPresetId): boolean {
-  return preset === "piano" || preset === "electric-piano";
+  return resolveInstrument(preset).needsLoading;
 }

--- a/lib/state/playbackSettingsStore.ts
+++ b/lib/state/playbackSettingsStore.ts
@@ -1,0 +1,50 @@
+/**
+ * Playback Settings Store
+ *
+ * Holds user-facing playback controls (velocity, humanization, sustain, style)
+ * and persists them to localStorage via Zustand's `persist` middleware so the
+ * feel of playback carries across sessions.
+ */
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { PlaybackStyle, SustainMode } from "../audio/humanization";
+
+export const CHORD_VELOCITY_MIN = 0.2;
+export const CHORD_VELOCITY_MAX = 1;
+
+interface PlaybackSettingsState {
+  /** Base chord velocity (0.20–1.00). */
+  chordVelocity: number;
+  /** Humanization amount (0 = off, 1 = full natural variation). */
+  humanize: number;
+  /** Sustain behaviour. */
+  sustainMode: SustainMode;
+  /** Articulation style. */
+  playbackStyle: PlaybackStyle;
+
+  setChordVelocity: (value: number) => void;
+  setHumanize: (value: number) => void;
+  setSustainMode: (mode: SustainMode) => void;
+  setPlaybackStyle: (style: PlaybackStyle) => void;
+}
+
+export const usePlaybackSettingsStore = create<PlaybackSettingsState>()(
+  persist(
+    (set) => ({
+      chordVelocity: 0.7,
+      humanize: 0.5,
+      sustainMode: "natural",
+      playbackStyle: "block",
+
+      setChordVelocity: (value) =>
+        set({ chordVelocity: Math.min(CHORD_VELOCITY_MAX, Math.max(CHORD_VELOCITY_MIN, value)) }),
+      setHumanize: (value) => set({ humanize: Math.min(1, Math.max(0, value)) }),
+      setSustainMode: (mode) => set({ sustainMode: mode }),
+      setPlaybackStyle: (style) => set({ playbackStyle: style }),
+    }),
+    {
+      name: "harmonia-playback-settings",
+    },
+  ),
+);


### PR DESCRIPTION
Generated progressions previously played each chord with a single
triggerAttackRelease call at uniform velocity and perfectly quantized
timing, which sounded mechanical. Playback now triggers notes
individually with subtle per-note velocity and timing variation.

- lib/audio/humanization.ts: pure engine for per-note velocity swing
  (+/-0.12 max), timing jitter (+/-12ms), and optional soft strum
- lib/state/playbackSettingsStore.ts: persisted Zustand store for
  velocity, humanize amount, sustain mode, and playback style
- synthPresets.ts: refactor instruments into a registry for future
  expansion; add sustainMode -> sampler release control
- app/page.tsx: apply humanization to playback, previews, and melody;
  Playback settings UI in the Audio menu; "Loading <instrument>..." state
- README: document Playback settings and audio architecture/performance

Keeps the existing sampled Salamander piano (no bundle/asset increase).