### PR TITLE
Fix mobile chord card + piano roll layout bugs

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -309,6 +309,40 @@
   --vert-key-active-w: #fde8e1;
   --vert-key-active-b: #5a2d22;
   --vert-col-hover:    rgba(232, 133, 106, 0.06);
+  /* Fixed roll header height keeps the playhead below the header row and
+     keeps every column header aligned. */
+  --roll-header-h:     30px;
+}
+
+/* ─────────────────────────────────────────────
+   CHORD CARD ROW (PROGRESSION PAGE)
+   Mirrors the piano-roll column flex pattern via a --card-flex variable.
+───────────────────────────────────────────── */
+.chord-card-row {
+  display: flex;
+  flex: 1;
+  gap: 6px;
+  min-width: 0;
+}
+.chord-card {
+  flex: var(--card-flex, 1);
+  min-width: 0;
+}
+/* Mobile: uniform, readable, horizontally-scrollable cards (no shrinking,
+   no overlap). Desktop keeps the duration-proportional flex layout above. */
+@media (max-width: 1023px) {
+  .chord-card-row {
+    flex: none;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scroll-snap-type: x proximity;
+    padding-bottom: 4px;
+  }
+  .chord-card {
+    flex: 1 1 0;
+    min-width: 150px;
+    scroll-snap-align: start;
+  }
 }
 
 .piano-roll-section {
@@ -393,10 +427,11 @@
   position: relative;
 }
 
-/* Playhead line during playback */
+/* Playhead line during playback — starts below the header row so it never
+   draws through chord labels / badges / the header border. */
 .playhead-line {
   position: absolute;
-  top: 0;
+  top: var(--roll-header-h);
   bottom: 0;
   width: 2px;
   background: var(--vert-accent-coral);
@@ -415,6 +450,13 @@
   cursor: pointer;
   transition: background 0.1s;
   position: relative;
+}
+/* Mobile: wider columns so headers stay readable and align with the uniform
+   150px chord cards; engages horizontal scroll with the right-edge fade. */
+@media (max-width: 1023px) {
+  .roll-column {
+    min-width: 150px;
+  }
 }
 .roll-col-cells {
   position: relative;
@@ -436,6 +478,12 @@
   position: sticky;
   top: 0;
   z-index: 2;
+  /* Fixed height keeps headers aligned and matches the playhead top offset. */
+  height: var(--roll-header-h);
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
 }
 .roll-col-header .col-numeral {
   font-family: var(--font-geist-mono), monospace;
@@ -446,6 +494,15 @@
   font-size: 0.75rem;
   font-weight: 600;
   line-height: 1.2;
+  min-width: 0;
+  width: 100%;
+}
+/* Chord symbol truncates instead of colliding with the badge/dot. */
+.roll-col-header .col-chord-symbol {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .roll-column.playing .roll-col-header {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1079,8 +1079,8 @@ export default function HarmoniaPage() {
               >
 
                 {/* Chord cards row — offset by piano key width, flex-matched to roll columns */}
-                <div className="flex" style={{ paddingLeft: 53 }}>
-                  <div className="flex flex-1 gap-1.5">
+                <div className="relative flex" style={{ paddingLeft: 53 }}>
+                  <div className="chord-card-row">
                     {currentProgression.chords.map((chord, index) => {
                       const isActive = playbackIndex === index;
                       const previewNotes =
@@ -1106,72 +1106,76 @@ export default function HarmoniaPage() {
                             duration: 0.35,
                             ease: [0.22, 1, 0.36, 1],
                           }}
-                          style={{ flex: colFlex, minWidth: 0 }}
+                          style={{ "--card-flex": colFlex } as React.CSSProperties}
                           onClick={() => handleChordClick(previewNotes, index)}
-                          className={`relative flex flex-col items-center justify-center rounded-xl px-2.5 py-3 lg:px-3 lg:py-5 border transition-all duration-200 cursor-pointer select-none ${
+                          className={`chord-card relative flex flex-col rounded-xl px-2.5 py-3 lg:px-3 lg:py-4 border transition-all duration-200 cursor-pointer select-none ${
                             isActive
-                              ? "bg-accent/10 border-accent shadow-md ring-2 ring-accent/20"
+                              ? "bg-accent/10 border-accent shadow-md ring-2 ring-inset ring-accent/20"
                               : selectedChordIndex === index
-                                ? "bg-accent/5 border-accent ring-2 ring-accent/40 shadow-sm"
+                                ? "bg-accent/5 border-accent ring-2 ring-inset ring-accent/40 shadow-sm"
                                 : chord.isLocked
-                                  ? "bg-surface border-accent/30 ring-1 ring-accent/10"
+                                  ? "bg-surface border-accent/30 ring-1 ring-inset ring-accent/10"
                                   : "bg-surface border-border-subtle shadow-sm hover:border-accent/60 hover:shadow-md hover:-translate-y-0.5 active:translate-y-0 active:shadow-sm"
                           }`}
                         >
                           {/* Playback glow pulse */}
                           {isActive && (
                             <motion.div
-                              className="absolute inset-0 rounded-xl bg-accent/5"
+                              className="absolute inset-0 rounded-xl bg-accent/5 pointer-events-none"
                               animate={{ opacity: [0.3, 0.08, 0.3] }}
                               transition={{ duration: 1.2, repeat: Infinity, ease: "easeInOut" }}
                             />
                           )}
 
-                          {/* Top-left: source badge */}
-                          {sourceType !== "generated" && (
-                            <div className={`absolute top-1.5 left-1.5 px-1.5 py-0.5 rounded text-[8px] font-semibold ${SOURCE_BADGE[sourceType].color}`}>
-                              {SOURCE_BADGE[sourceType].label}
+                          {/* Top meta row: source badge (left) + controls (right) */}
+                          <div className="relative z-10 flex w-full items-center justify-between gap-1 min-h-[20px]">
+                            {sourceType !== "generated" ? (
+                              <span className={`px-1.5 py-0.5 rounded text-[8px] font-semibold whitespace-nowrap ${SOURCE_BADGE[sourceType].color}`}>
+                                {SOURCE_BADGE[sourceType].label}
+                              </span>
+                            ) : (
+                              <span aria-hidden className="block w-px" />
+                            )}
+                            <div className="flex items-center gap-0.5 shrink-0">
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  openSubstitution(index);
+                                  setSelectedChordIndex(index);
+                                }}
+                                className="p-1.5 lg:p-1 rounded-md text-muted/30 hover:text-accent/70 transition-colors"
+                                title="Substitute chord"
+                              >
+                                <Shuffle className="w-3 h-3" />
+                              </button>
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  toggleLock(index);
+                                }}
+                                className={`p-1.5 lg:p-1 rounded-md transition-colors ${
+                                  chord.isLocked
+                                    ? "text-accent hover:text-accent/80"
+                                    : "text-muted/30 hover:text-muted/60"
+                                }`}
+                                title={chord.isLocked ? "Unlock chord" : "Lock chord"}
+                              >
+                                {chord.isLocked ? (
+                                  <Lock className="w-3 h-3" />
+                                ) : (
+                                  <Unlock className="w-3 h-3" />
+                                )}
+                              </button>
                             </div>
-                          )}
-
-                          {/* Top-right: Lock toggle + Substitute button */}
-                          <div className="absolute top-1.5 right-1.5 flex items-center gap-0.5">
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                openSubstitution(index);
-                                setSelectedChordIndex(index);
-                              }}
-                              className="p-1.5 lg:p-1 rounded-md text-muted/30 hover:text-accent/70 transition-colors"
-                              title="Substitute chord"
-                            >
-                              <Shuffle className="w-3 h-3" />
-                            </button>
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                toggleLock(index);
-                              }}
-                              className={`p-1.5 lg:p-1 rounded-md transition-colors ${
-                                chord.isLocked
-                                  ? "text-accent hover:text-accent/80"
-                                  : "text-muted/30 hover:text-muted/60"
-                              }`}
-                              title={chord.isLocked ? "Unlock chord" : "Lock chord"}
-                            >
-                              {chord.isLocked ? (
-                                <Lock className="w-3 h-3" />
-                              ) : (
-                                <Unlock className="w-3 h-3" />
-                              )}
-                            </button>
                           </div>
 
+                          {/* Centered chord content */}
+                          <div className="relative z-10 flex flex-1 flex-col items-center justify-center text-center">
                           <div className="text-xs font-mono text-muted mb-0.5 lg:mb-1 tracking-wider">
                             {chord.romanNumeral}
                           </div>
-                          <div className="text-lg lg:text-xl font-semibold mb-1 lg:mb-1.5">{chord.symbol}</div>
-                          <div className="text-[10px] text-muted opacity-70">
+                          <div className="text-lg lg:text-xl font-semibold mb-1 lg:mb-1.5 whitespace-nowrap">{chord.symbol}</div>
+                          <div className="text-[10px] text-muted opacity-70 whitespace-nowrap">
                             {chord.notes.join(" · ")}
                           </div>
                           {chord.durationClass && chord.durationClass !== "full" && (
@@ -1194,10 +1198,13 @@ export default function HarmoniaPage() {
                               revert
                             </button>
                           )}
+                          </div>
                         </motion.div>
                       );
                     })}
                   </div>
+                  {/* Mobile scroll affordance */}
+                  <div className="lg:hidden pointer-events-none absolute right-0 top-0 bottom-0 w-5 bg-gradient-to-l from-black/10 to-transparent" />
                 </div>
 
                 {/* Voicing feedback removed and added to controls bar */}

--- a/components/creative/InteractivePianoRoll.tsx
+++ b/components/creative/InteractivePianoRoll.tsx
@@ -94,6 +94,14 @@ const SOURCE_BADGE_LABELS: Record<ChordSourceType, string> = {
   manual: "Edit",
 };
 
+// Compact dot indicator used on narrow (mobile) columns where a text badge
+// would overlap the chord name.
+const SOURCE_DOT_COLORS: Record<ChordSourceType, string> = {
+  generated: "bg-blue-400",
+  substituted: "bg-purple-400",
+  manual: "bg-emerald-400",
+};
+
 export function InteractivePianoRoll({
   chords,
   playingIndex,
@@ -383,11 +391,19 @@ export function InteractivePianoRoll({
                   title={`${chord.romanNumeral} \u2014 ${chord.symbol}`}
                 >
                   <div className="col-chord-name flex items-center gap-1">
-                    {chord.symbol}
+                    <span className="col-chord-symbol">{chord.symbol}</span>
                     {sourceType && sourceType !== "generated" && (
-                      <span className={`inline-block px-1 py-0 rounded text-[8px] font-semibold ${SOURCE_BADGE_COLORS[sourceType]}`}>
-                        {SOURCE_BADGE_LABELS[sourceType]}
-                      </span>
+                      <>
+                        {/* Mobile: compact dot so the badge never overlaps the name */}
+                        <span
+                          className={`lg:hidden inline-block w-1.5 h-1.5 rounded-full shrink-0 ${SOURCE_DOT_COLORS[sourceType]}`}
+                          title={SOURCE_BADGE_LABELS[sourceType]}
+                        />
+                        {/* Desktop: full text badge */}
+                        <span className={`hidden lg:inline-block px-1 py-0 rounded text-[8px] font-semibold shrink-0 ${SOURCE_BADGE_COLORS[sourceType]}`}>
+                          {SOURCE_BADGE_LABELS[sourceType]}
+                        </span>
+                      </>
                     )}
                   </div>
                 </div>


### PR DESCRIPTION
- Chord cards: replace inline flex with .chord-card/.chord-card-row classes;
  mobile gets uniform 150px-min, horizontally scrollable cards (no overlap,
  no shrinking) while desktop keeps duration-proportional flex widths.
- Move source badge + shuffle/lock into an in-flow top meta row so they no
  longer overlap the chord name/notes; ring-inset keeps selected border in
  bounds; chord symbol/notes no-wrap.
- Add mobile right-edge fade affordance to the card row.
- Piano roll header: truncate chord symbol, swap text badge for a compact
  dot on mobile, fixed header height; wider mobile column min-width.
- Playhead now starts below the header row via --roll-header-h offset.