### PR TITLE
Fix melody generation to respect corrected chord notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Generate musically coherent chord progressions in any key and mode. Refine them 
 - **Streamlined action bar** — A single horizontal row of actions (Play · Chords · Melody · Save · Audio) keeps every primary control visible at once. Compact, clutter-free chord cards on mobile give the piano roll more room, while desktop retains its roomier spacing
 - **Voicing feedback** — Rate generated voicings with thumbs up/down in a lightweight card below the action bar; ratings persist across sessions via localStorage. View approval trends over time in the feedback chart
 - **Melody overlay** — Toggle melody generation to hear a monophonic melody line over chords. Three styles: Lyrical (stepwise, longer notes), Rhythmic (shorter notes, syncopation), and Arpeggiated (chord-tone focused). Melody notes are displayed directly on the piano roll with a toggle button and distinct amber styling. Melody uses the same sound preset as chords (Piano, EP, or Organ)
+- **Chord-aware melody** — Melody chord tones are derived from the same single source of truth as the voicings (`getChordPitchClasses`), so the melody follows the actual chord notes — including chromatic chord tones such as the F♯ of a `D7` secondary dominant that the diatonic scale alone can't reach. Two harmony modes control how tightly the melody hugs the chords: **Expressive** (default) keeps scale/passing-tone freedom while strongly preferring chord tones on strong beats and avoiding notes a semitone off a chord tone, and **Strict** pins every strong-beat note to an actual chord tone
 - **Favorite progressions** — Save progressions to a persistent favorites list. Load or delete saved progressions at any time
 - **Adjustable BPM** — 60–180 BPM with looping playback
 
@@ -94,7 +95,7 @@ The piano and electric piano are **sampled** (Salamander Grand / Casio) and stre
 7. **Export MIDI** to bring your progression into a DAW
 8. Click the **substitute icon** on a chord card to browse theory-guided replacement options
 9. **Double-click** the piano roll grid to add or remove individual notes — chord labels update automatically
-10. Click **Melody** to generate a melody line — choose a style (Lyrical, Rhythmic, Arpeggio) and click **Melody** again for a new line. Use the **Audio** button in the action bar to mute/unmute chords and melody and to adjust playback feel — **Velocity**, **Humanize**, **Sustain**, and **Soft Strum** vs **Block Chord**
+10. Click **Melody** to generate a melody line — choose a style (Lyrical, Rhythmic, Arpeggio) and a harmony mode (**Expressive** or **Strict**), then click **Melody** again for a new line. Use the **Audio** button in the action bar to mute/unmute chords and melody and to adjust playback feel — **Velocity**, **Humanize**, **Sustain**, and **Soft Strum** vs **Block Chord**
 11. Click **Save** to bookmark a progression to your favorites. Click **Favorites** to view, load, or remove saved progressions
 
 ### Harmonic Sketchpad

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,7 +29,7 @@ import {
 import type { Mode } from "@/lib/theory/harmonyEngine";
 import type { SubstitutionOption, ChordSourceType } from "@/lib/creative/types";
 import type { VoicingStyle, VoiceCount } from "@/lib/music/generators/advanced/types";
-import type { MelodyStyle } from "@/lib/music/generators/melody/types";
+import type { MelodyStyle, MelodyHarmony } from "@/lib/music/generators/melody/types";
 
 const NOTES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
 const MODES: { value: Mode; label: string }[] = [
@@ -57,6 +57,11 @@ const MELODY_STYLES: { value: MelodyStyle; label: string }[] = [
   { value: "lyrical", label: "Lyrical" },
   { value: "rhythmic", label: "Rhythmic" },
   { value: "arpeggiated", label: "Arpeggio" },
+];
+
+const MELODY_HARMONIES: { value: MelodyHarmony; label: string }[] = [
+  { value: "expressive", label: "Expressive" },
+  { value: "strict", label: "Strict" },
 ];
 
 /** Map durationClass to a flex multiplier for column width alignment. */
@@ -112,8 +117,10 @@ export default function HarmoniaPage() {
     melody,
     melodyEnabled,
     melodyStyle,
+    melodyHarmony,
     setMelodyEnabled,
     setMelodyStyle,
+    setMelodyHarmony,
     generateMelodyForProgression,
   } = useProgressionStore();
 
@@ -789,6 +796,17 @@ export default function HarmoniaPage() {
                 >
                   {MELODY_STYLES.map((ms) => (
                     <option key={ms.value} value={ms.value}>{ms.label}</option>
+                  ))}
+                </select>
+                <div className="w-px h-4 bg-border-subtle mx-1" />
+                <select
+                  value={melodyHarmony}
+                  onChange={(e) => setMelodyHarmony(e.target.value as any)}
+                  className="flex-1 bg-transparent hover:bg-surface px-2 py-1.5 text-sm font-medium outline-none appearance-none rounded-lg cursor-pointer transition-colors text-center"
+                  title="Melody Harmony — how tightly the melody follows the chord tones"
+                >
+                  {MELODY_HARMONIES.map((mh) => (
+                    <option key={mh.value} value={mh.value}>{mh.label}</option>
                   ))}
                 </select>
                 <div className="w-px h-4 bg-border-subtle mx-1" />

--- a/lib/music/generators/melody/__tests__/melodyHarmony.test.ts
+++ b/lib/music/generators/melody/__tests__/melodyHarmony.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { generateMelody } from "../generateMelody";
+import type { MelodyGenerationOptions } from "../types";
+import { midiToPitchClass, type PitchClass } from "@/lib/theory/midiUtils";
+
+// C major scale — note that F# (the third of a D7) is NOT diatonic here, which
+// is exactly the case the melody generator used to mishandle.
+const C_MAJOR: PitchClass[] = ["C", "D", "E", "F", "G", "A", "B"];
+
+// A C-major context containing a D7 secondary dominant (D F# A C). The F# and C
+// are the harmonically critical tones; F natural is the diatonic clash a
+// semitone below F#.
+function options(
+  overrides: Partial<MelodyGenerationOptions> = {},
+): MelodyGenerationOptions {
+  return {
+    scalePitchClasses: C_MAJOR,
+    chords: [
+      { midiNotes: [], pitchClasses: ["C", "E", "G"], root: "C", durationClass: "full" },
+      { midiNotes: [], pitchClasses: ["D", "F#", "A", "C"], root: "D", durationClass: "full" },
+      { midiNotes: [], pitchClasses: ["G", "B", "D"], root: "G", durationClass: "full" },
+    ],
+    style: "arpeggiated",
+    octave: 5,
+    seed: 12345,
+    ...overrides,
+  };
+}
+
+function isChordTone(midi: number, pcs: PitchClass[]): boolean {
+  return pcs.includes(midiToPitchClass(midi));
+}
+
+function isSemitoneClash(midi: number, pcs: PitchClass[]): boolean {
+  if (isChordTone(midi, pcs)) return false;
+  return isChordTone(midi - 1, pcs) || isChordTone(midi + 1, pcs);
+}
+
+describe("melody harmony — chord-tone awareness", () => {
+  it("is deterministic for a fixed seed", () => {
+    const a = generateMelody(options());
+    const b = generateMelody(options());
+    expect(a.notes.map((n) => n.midi)).toEqual(b.notes.map((n) => n.midi));
+  });
+
+  it("can reach a chromatic chord tone (F# over D7 in C major)", () => {
+    // Search several seeds so we don't depend on one RNG draw — the point is
+    // that F# is *reachable* at all, which it never was when candidates came
+    // only from the diatonic scale.
+    let sawFSharp = false;
+    for (let seed = 0; seed < 40 && !sawFSharp; seed++) {
+      const melody = generateMelody(options({ seed }));
+      sawFSharp = melody.notes.some(
+        (n) => n.chordIndex === 1 && midiToPitchClass(n.midi) === "F#",
+      );
+    }
+    expect(sawFSharp).toBe(true);
+  });
+
+  it("never plays a strong-beat semitone clash against the chord (expressive)", () => {
+    for (let seed = 0; seed < 40; seed++) {
+      const melody = generateMelody(options({ seed, harmony: "expressive" }));
+      for (const note of melody.notes) {
+        const chordPCs = options().chords[note.chordIndex].pitchClasses;
+        const strongBeat = note.startBeat % 2 === 0;
+        if (strongBeat) {
+          expect(isSemitoneClash(note.midi, chordPCs)).toBe(false);
+        }
+      }
+    }
+  });
+
+  it("strict mode pins every strong-beat note to a chord tone", () => {
+    for (let seed = 0; seed < 40; seed++) {
+      const melody = generateMelody(options({ seed, harmony: "strict" }));
+      for (const note of melody.notes) {
+        const chordPCs = options().chords[note.chordIndex].pitchClasses;
+        const strongBeat = note.startBeat % 2 === 0;
+        if (strongBeat) {
+          expect(isChordTone(note.midi, chordPCs)).toBe(true);
+        }
+      }
+    }
+  });
+});

--- a/lib/music/generators/melody/generateMelody.ts
+++ b/lib/music/generators/melody/generateMelody.ts
@@ -14,7 +14,7 @@
 
 import { pitchClassToMidi, midiToNoteName, midiToPitchClass, type PitchClass } from "@/lib/theory/midiUtils";
 import type { DurationClass } from "../advanced/types";
-import type { Melody, MelodyNote, MelodyGenerationOptions } from "./types";
+import type { Melody, MelodyNote, MelodyGenerationOptions, MelodyHarmony } from "./types";
 
 /* ─── Helpers ─── */
 
@@ -55,6 +55,22 @@ function buildScaleMidiSet(scalePitchClasses: PitchClass[], octave: number): num
   return notes.sort((a, b) => a - b);
 }
 
+/**
+ * Build an ordered set of chord-tone MIDI notes spanning the target range.
+ * Mirrors buildScaleMidiSet but for a chord's pitch classes — crucially this
+ * materialises chromatic chord tones (e.g. the F# of a D7 in C major) that are
+ * absent from the diatonic scale set, so the melody can actually reach them.
+ */
+function buildChordMidiSet(chordPitchClasses: PitchClass[], octave: number): number[] {
+  const notes: number[] = [];
+  for (let oct = octave - 1; oct <= octave + 1; oct++) {
+    for (const pc of chordPitchClasses) {
+      notes.push(pitchClassToMidi(pc, oct));
+    }
+  }
+  return notes.sort((a, b) => a - b);
+}
+
 /** Find the closest scale tone to a target MIDI note. */
 function closestScaleTone(target: number, scaleMidi: number[]): number {
   let best = scaleMidi[0];
@@ -82,6 +98,20 @@ function stepByDegrees(current: number, degrees: number, scaleMidi: number[]): n
 
 function isChordTone(midi: number, chordPitchClasses: PitchClass[]): boolean {
   return chordPitchClasses.includes(midiToPitchClass(midi));
+}
+
+/**
+ * Whether `midi` is a non-chord-tone sitting a semitone away from a chord tone.
+ * These are the worst offenders harmonically (e.g. a diatonic F natural a
+ * semitone below the F# third of a D7) and are penalised / avoided on strong
+ * beats so the melody stops clashing with the now-correct chord notes.
+ */
+function isSemitoneClash(midi: number, chordPitchClasses: PitchClass[]): boolean {
+  if (isChordTone(midi, chordPitchClasses)) return false;
+  return (
+    isChordTone(midi - 1, chordPitchClasses) ||
+    isChordTone(midi + 1, chordPitchClasses)
+  );
 }
 
 /* ─── Smoothness cost (adapted from voiceLeading.ts) ─── */
@@ -186,7 +216,9 @@ function pickNextPitch(
   current: number,
   chordPCs: PitchClass[],
   scaleMidi: number[],
+  chordMidi: number[],
   style: "lyrical" | "rhythmic" | "arpeggiated",
+  harmony: MelodyHarmony,
   tension: number,
   prevDirection: number,
   rng: () => number,
@@ -196,10 +228,26 @@ function pickNextPitch(
   const baseRange = style === "arpeggiated" ? 12 : style === "lyrical" ? 7 : 5;
   const range = baseRange + Math.floor(tension * 5); // tension widens range
 
-  // Gather candidates
-  const candidates = scaleMidi.filter(
-    (m) => Math.abs(m - current) <= range,
+  // Candidate universe: scale tones unioned with chord tones, so chromatic
+  // chord tones (outside the diatonic scale) are reachable. De-duplicate.
+  const universe = Array.from(new Set([...scaleMidi, ...chordMidi])).sort(
+    (a, b) => a - b,
   );
+
+  // Gather candidates within range
+  let candidates = universe.filter((m) => Math.abs(m - current) <= range);
+
+  // Strict harmony: on strong beats restrict to actual chord tones. If none are
+  // in range, fall back to the nearest chord tone so the beat still lands true.
+  if (harmony === "strict" && isStrongBeat) {
+    const chordCandidates = candidates.filter((m) => isChordTone(m, chordPCs));
+    if (chordCandidates.length > 0) {
+      candidates = chordCandidates;
+    } else if (chordMidi.length > 0) {
+      return { midi: closestScaleTone(current, chordMidi), direction: 0 };
+    }
+  }
+
   if (candidates.length === 0) {
     return { midi: current, direction: 0 };
   }
@@ -208,14 +256,20 @@ function pickNextPitch(
   const scored = candidates.map((m) => {
     let score = melodicCost(current, m, prevDirection);
 
-    // Chord tone bonus on strong beats
+    // Chord tone bonus on strong beats (stronger pull toward chord tones)
     if (isStrongBeat && isChordTone(m, chordPCs)) {
-      score -= 3;
+      score -= 5;
     }
 
     // Non-strong beat: mild chord tone preference
     if (!isStrongBeat && isChordTone(m, chordPCs)) {
       score -= 1;
+    }
+
+    // Avoid-note penalty: a non-chord-tone a semitone off a chord tone clashes
+    // hard against the chord. Penalise heavily on strong beats, mildly elsewhere.
+    if (isSemitoneClash(m, chordPCs)) {
+      score += isStrongBeat ? 6 : 2;
     }
 
     // Penalise staying on same note in lyrical style
@@ -303,6 +357,7 @@ export function generateMelody(options: MelodyGenerationOptions): Melody {
     scalePitchClasses,
     chords,
     style,
+    harmony = "expressive",
     tensionCurve,
     octave = 5,
     seed,
@@ -326,6 +381,7 @@ export function generateMelody(options: MelodyGenerationOptions): Melody {
     const chord = chords[ci];
     const chordBeats = durationClassToBeats(chord.durationClass);
     const chordPCs = chord.pitchClasses;
+    const chordMidi = buildChordMidiSet(chordPCs, octave);
     const tension = tensions[ci] ?? 0.3;
 
     const rhythm = generateRhythm(chordBeats, style, tension, rng);
@@ -348,7 +404,9 @@ export function generateMelody(options: MelodyGenerationOptions): Melody {
           currentPitch,
           chordPCs,
           scaleMidi,
+          chordMidi,
           style,
+          harmony,
           tension,
           prevDirection,
           rng,
@@ -364,6 +422,23 @@ export function generateMelody(options: MelodyGenerationOptions): Melody {
       const high = pitchClassToMidi(scalePitchClasses[0], octave + 1);
       if (currentPitch < low) currentPitch = closestScaleTone(low, scaleMidi);
       if (currentPitch > high) currentPitch = closestScaleTone(high, scaleMidi);
+
+      // Harmony correction on strong beats. This is the final say, so it also
+      // catches notes produced by the leap-recovery branch (which steps through
+      // the scale and could otherwise land a clash on a downbeat):
+      //   - strict:     snap any non-chord-tone to the nearest chord tone.
+      //   - expressive: only snap a semitone clash (e.g. F natural under F#).
+      const inRangeChord = chordMidi.filter((m) => m >= low && m <= high);
+      if (isStrongBeat && inRangeChord.length > 0) {
+        const needsSnap =
+          harmony === "strict"
+            ? !isChordTone(currentPitch, chordPCs)
+            : isSemitoneClash(currentPitch, chordPCs);
+        if (needsSnap) {
+          currentPitch = closestScaleTone(currentPitch, inRangeChord);
+          prevPitch = currentPitch;
+        }
+      }
 
       const pc = midiToPitchClass(currentPitch);
 

--- a/lib/music/generators/melody/types.ts
+++ b/lib/music/generators/melody/types.ts
@@ -29,6 +29,16 @@ export type Melody = {
 /** Style of melody generation. */
 export type MelodyStyle = "lyrical" | "rhythmic" | "arpeggiated";
 
+/**
+ * How tightly the melody is bound to the underlying chord's tones.
+ *   - expressive: chord tones (incl. chromatic ones) are reachable and strongly
+ *                 preferred on strong beats; diatonic notes a semitone off a
+ *                 chord tone are avoided, but scale/passing tones remain allowed.
+ *   - strict:     every strong-beat note must be an actual chord tone; scale and
+ *                 passing tones are only permitted on weak beats.
+ */
+export type MelodyHarmony = "expressive" | "strict";
+
 /** Options for the melody generator. */
 export type MelodyGenerationOptions = {
   /** Scale pitch classes (7 notes) in order. */
@@ -41,6 +51,8 @@ export type MelodyGenerationOptions = {
     durationClass?: DurationClass;
   }[];
   style: MelodyStyle;
+  /** How tightly the melody follows the chord tones (default "expressive"). */
+  harmony?: MelodyHarmony;
   /** Tension curve (0-1 per chord) — drives contour and note density. */
   tensionCurve?: number[];
   /** Octave for the melody (default 5). */

--- a/lib/state/progressionStore.ts
+++ b/lib/state/progressionStore.ts
@@ -9,7 +9,8 @@ import type { ChordSourceType, SubstitutionOption } from "../creative/types";
 import { getSubstitutions } from "../creative/substitutionEngine";
 import { interpretChord } from "../creative/chordInterpreter";
 import { generateMelody } from "../music/generators/melody/generateMelody";
-import type { Melody, MelodyNote, MelodyStyle } from "../music/generators/melody/types";
+import type { Melody, MelodyNote, MelodyStyle, MelodyHarmony } from "../music/generators/melody/types";
+import { getChordPitchClasses } from "../theory/chordSymbol";
 import { getScaleDefinition } from "../theory/scale";
 import type { ScaleType } from "../theory/types";
 
@@ -47,6 +48,7 @@ interface ProgressionState {
     melody: Melody | null;
     melodyEnabled: boolean;
     melodyStyle: MelodyStyle;
+    melodyHarmony: MelodyHarmony;
     chordsEnabled: boolean;
 
     setSettings: (settings: Partial<Pick<ProgressionState, "rootKey" | "mode" | "complexity" | "numChords" | "bpm" | "voicingStyle" | "voiceCount">>) => void;
@@ -74,6 +76,7 @@ interface ProgressionState {
     setMelodyEnabled: (enabled: boolean) => void;
     setChordsEnabled: (enabled: boolean) => void;
     setMelodyStyle: (style: MelodyStyle) => void;
+    setMelodyHarmony: (harmony: MelodyHarmony) => void;
     generateMelodyForProgression: () => void;
     clearMelody: () => void;
     addMelodyNote: (note: MelodyNote) => void;
@@ -148,6 +151,7 @@ export const useProgressionStore = create<ProgressionState>((set, get) => ({
     melody: null,
     melodyEnabled: false,
     melodyStyle: "lyrical",
+    melodyHarmony: "expressive",
     chordsEnabled: true,
 
     setSettings: (settings) => {
@@ -588,8 +592,15 @@ export const useProgressionStore = create<ProgressionState>((set, get) => ({
         }
     },
 
+    setMelodyHarmony: (harmony: MelodyHarmony) => {
+        set({ melodyHarmony: harmony });
+        if (get().melodyEnabled && get().currentProgression) {
+            get().generateMelodyForProgression();
+        }
+    },
+
     generateMelodyForProgression: () => {
-        const { currentProgression, rootKey, mode, melodyStyle } = get();
+        const { currentProgression, rootKey, mode, melodyStyle, melodyHarmony } = get();
         if (!currentProgression) return;
 
         const rootPC = (normalizeToPitchClass(rootKey) || "C") as PitchClass;
@@ -603,17 +614,25 @@ export const useProgressionStore = create<ProgressionState>((set, get) => ({
         const scaleType = MODE_TO_SCALE[mode] ?? "major";
         const scale = getScaleDefinition(rootPC, scaleType);
 
-        const chords = currentProgression.chords.map((c) => ({
-            midiNotes: c.midiNotes ?? [],
-            pitchClasses: (c.notes ?? []) as PitchClass[],
-            root: (c.root ?? c.notes[0] ?? "C") as PitchClass,
-            durationClass: c.durationClass,
-        }));
+        const chords = currentProgression.chords.map((c) => {
+            // Derive chord tones from the chord symbol — the single source of
+            // truth established by the voicing fix. Fall back to the voiced
+            // pitch classes only when the symbol can't be parsed.
+            const canonical = getChordPitchClasses(c.symbol);
+            const pitchClasses = (canonical.length ? canonical : (c.notes ?? [])) as PitchClass[];
+            return {
+                midiNotes: c.midiNotes ?? [],
+                pitchClasses,
+                root: (c.root ?? c.notes[0] ?? "C") as PitchClass,
+                durationClass: c.durationClass,
+            };
+        });
 
         const melody = generateMelody({
             scalePitchClasses: scale.pitchClasses,
             chords,
             style: melodyStyle,
+            harmony: melodyHarmony,
             octave: 5,
         });
 


### PR DESCRIPTION
The recent voicing fix made getChordPitchClasses the single source of
truth for a chord's notes, but the melody generator was never updated.
It drew candidate pitches only from the diatonic key scale and treated
chord membership as a soft scoring nudge, so chromatic chord tones (e.g.
the F# of a D7 secondary dominant in C major) were unreachable and the
melody would play the clashing diatonic F natural instead.

Changes:
- Derive melody chord tones from getChordPitchClasses(symbol) instead of
  the voiced subset, matching the voicing fix's source of truth.
- Materialize chord tones across the playable range and union them into
  the melody candidate pool so chromatic chord tones are reachable.
- Strengthen the strong-beat chord-tone preference and add an avoid-note
  penalty for non-chord-tones a semitone off a chord tone.
- Add a selectable harmony mode: Expressive (default) and Strict (every
  strong-beat note must be a chord tone), wired through the store and a
  new dropdown in the melody controls.
- Add unit tests covering reachability, clash avoidance, strict mode, and
  determinism; document the modes in the README.