### PR TITLE
Fix Electric Piano silently failing to load on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Instruments are defined in a small registry (`lib/audio/synthPresets.ts`) so new
 
 The piano and electric piano are **sampled** (Salamander Grand / Casio) and stream from the Tone.js CDN — humanization adds **no bundle or asset weight**, no new downloads, and negligible CPU. A "Loading Piano…" state covers the brief sample preload on first selection. (Note: the Salamander set is single-velocity, so velocity changes loudness rather than timbre — a deliberate trade for fast load, small footprint, and mobile/browser compatibility.)
 
+Sample loading is resilient by design via the `useInstrument` hook (`lib/audio/useInstrument.ts`), shared by the main page and the Sketchpad. Each sample-based preset is created with both `onload` and `onerror` callbacks plus a load timeout. If samples fail to download or stall — common on flaky mobile networks — the instrument **automatically falls back to the always-available FM Organ synth** and surfaces a brief, dismissible notice, so playback never gets stuck on an endless "Loading…" spinner.
+
 ## Usage
 
 ### Chord Progression Generator

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,13 +19,12 @@ import { FeedbackChart } from "@/components/feedback/FeedbackChart";
 import { useFavoritesStore } from "@/lib/favorites/favoritesStore";
 import {
   SOUND_PRESETS,
-  createSynthForPreset,
   createMelodySynthForPreset,
-  presetNeedsLoading,
   type SoundPresetId,
   type Synth,
   type MelodySynth,
 } from "@/lib/audio/synthPresets";
+import { useInstrument } from "@/lib/audio/useInstrument";
 import type { Mode } from "@/lib/theory/harmonyEngine";
 import type { SubstitutionOption, ChordSourceType } from "@/lib/creative/types";
 import type { VoicingStyle, VoiceCount } from "@/lib/music/generators/advanced/types";
@@ -133,7 +132,6 @@ export default function HarmoniaPage() {
   const [playbackIndex, setPlaybackIndex] = useState<number | null>(null);
   const [soundPreset, setSoundPreset] = useState<SoundPresetId>("piano");
   const [generationKey, setGenerationKey] = useState(0);
-  const [isSynthLoading, setIsSynthLoading] = useState(false);
   const [selectedChordIndex, setSelectedChordIndex] = useState<number | null>(null);
   const [showVoicingControls, setShowVoicingControls] = useState(false);
   const [showFavorites, setShowFavorites] = useState(false);
@@ -152,22 +150,13 @@ export default function HarmoniaPage() {
   const playheadRef = useRef<HTMLDivElement>(null);
   const animFrameRef = useRef<number | null>(null);
 
-  /* ─── Synth lifecycle ─── */
+  /* ─── Synth lifecycle (loading + fallback handled by the hook) ─── */
 
-  useEffect(() => {
-    setIsSynthLoading(presetNeedsLoading(soundPreset));
-    const synth = createSynthForPreset(soundPreset, {
-      sustainMode,
-      onLoaded: () => setIsSynthLoading(false),
-    });
-    synthRef.current = synth;
-
-    return () => {
-      synth.releaseAll();
-      synth.dispose();
-      synthRef.current = null;
-    };
-  }, [soundPreset, sustainMode]);
+  const {
+    isLoading: isSynthLoading,
+    loadError: synthLoadError,
+    dismissError: dismissSynthError,
+  } = useInstrument(soundPreset, { sustainMode, synthRef });
 
   /* ─── Melody synth lifecycle ─── */
 
@@ -874,6 +863,18 @@ export default function HarmoniaPage() {
 
         {/* ── Action Bar (Play · Chords · Melody · Save · Audio) ── */}
         <section>
+          {synthLoadError && (
+            <div className="flex items-center justify-center gap-2 mb-2 text-xs text-amber-600 dark:text-amber-400">
+              <span>{synthLoadError} couldn&apos;t load — using Organ instead.</span>
+              <button
+                onClick={dismissSynthError}
+                className="underline hover:no-underline"
+                aria-label="Dismiss notice"
+              >
+                Dismiss
+              </button>
+            </div>
+          )}
           <div className="flex items-center justify-center gap-1.5 sm:gap-2 lg:gap-3">
 
             {/* Primary: Play / Stop */}

--- a/components/sketchpad/HarmonicPreviewPanel.tsx
+++ b/components/sketchpad/HarmonicPreviewPanel.tsx
@@ -65,6 +65,8 @@ export function HarmonicPreviewPanel({
   soundPreset,
   onSoundPresetChange,
   isSynthLoading,
+  synthLoadError,
+  onDismissSynthError,
 }: {
   project: HarmonicSketchProject;
   section: HarmonicSection | null;
@@ -81,6 +83,8 @@ export function HarmonicPreviewPanel({
   soundPreset: string;
   onSoundPresetChange: (preset: any) => void;
   isSynthLoading: boolean;
+  synthLoadError: string | null;
+  onDismissSynthError: () => void;
 }) {
   const events = useMemo(() => variant?.events ?? [], [variant]);
   const isPlaying = playbackMode !== "stopped";
@@ -124,6 +128,19 @@ export function HarmonicPreviewPanel({
             ))}
           </select>
         </div>
+
+        {synthLoadError && (
+          <div className="flex items-center justify-between gap-2 mb-2 text-[11px] text-amber-600 dark:text-amber-400">
+            <span>{synthLoadError} couldn&apos;t load — using Organ.</span>
+            <button
+              onClick={onDismissSynthError}
+              className="underline hover:no-underline shrink-0"
+              aria-label="Dismiss notice"
+            >
+              Dismiss
+            </button>
+          </div>
+        )}
 
         {/* Playback controls */}
         <div className="flex flex-wrap gap-1.5">

--- a/components/sketchpad/Workspace.tsx
+++ b/components/sketchpad/Workspace.tsx
@@ -7,12 +7,8 @@ import { useSketchpadStore } from "@/lib/sketchpad/store";
 import { SongStructurePanel } from "./SongStructurePanel";
 import { SectionEditorPanel } from "./SectionEditorPanel";
 import { HarmonicPreviewPanel } from "./HarmonicPreviewPanel";
-import {
-  createSynthForPreset,
-  presetNeedsLoading,
-  type SoundPresetId,
-  type Synth,
-} from "@/lib/audio/synthPresets";
+import { type SoundPresetId, type Synth } from "@/lib/audio/synthPresets";
+import { useInstrument } from "@/lib/audio/useInstrument";
 
 function beatsToDuration(beats: number): string {
   switch (beats) {
@@ -37,8 +33,12 @@ export function SketchpadWorkspace({ project }: { project: HarmonicSketchProject
   } = useSketchpadStore();
 
   const [soundPreset, setSoundPreset] = useState<SoundPresetId>("piano");
-  const [isSynthLoading, setIsSynthLoading] = useState(false);
   const synthRef = useRef<Synth | null>(null);
+  const {
+    isLoading: isSynthLoading,
+    loadError: synthLoadError,
+    dismissError: dismissSynthError,
+  } = useInstrument(soundPreset, { synthRef });
   const scheduleIdsRef = useRef<number[]>([]);
 
   const activeSection = useMemo(
@@ -51,17 +51,6 @@ export function SketchpadWorkspace({ project }: { project: HarmonicSketchProject
     return activeSection.variants.find((v) => v.id === activeSection.activeVariantId) ?? null;
   }, [activeSection]);
 
-  // Synth lifecycle
-  useEffect(() => {
-    setIsSynthLoading(presetNeedsLoading(soundPreset));
-    const synth = createSynthForPreset(soundPreset, { onLoaded: () => setIsSynthLoading(false) });
-    synthRef.current = synth;
-    return () => {
-      synth.releaseAll();
-      synth.dispose();
-      synthRef.current = null;
-    };
-  }, [soundPreset]);
 
   // BPM sync
   useEffect(() => {
@@ -301,6 +290,8 @@ export function SketchpadWorkspace({ project }: { project: HarmonicSketchProject
         soundPreset={soundPreset}
         onSoundPresetChange={setSoundPreset}
         isSynthLoading={isSynthLoading}
+        synthLoadError={synthLoadError}
+        onDismissSynthError={dismissSynthError}
       />
     </div>
   );

--- a/lib/audio/synthPresets.ts
+++ b/lib/audio/synthPresets.ts
@@ -22,11 +22,15 @@ export interface CreateSynthOptions {
   sustainMode?: SustainMode;
   /** Called once the instrument is ready (immediately for synths). */
   onLoaded?: () => void;
+  /** Called if sample loading fails (sample-based instruments only). */
+  onError?: (err: Error) => void;
 }
 
 /** Options passed when building a melody instrument. */
 export interface CreateMelodySynthOptions {
   onLoaded?: () => void;
+  /** Called if sample loading fails (sample-based instruments only). */
+  onError?: (err: Error) => void;
 }
 
 /**
@@ -111,6 +115,19 @@ const SALAMANDER_URLS = {
   "F#2": "Fs2.mp3", "F#3": "Fs3.mp3", "F#4": "Fs4.mp3", "F#5": "Fs5.mp3",
 } as const;
 
+/**
+ * Electric Piano (Casio) sample map. The casio folder only ships the two
+ * samples used by the canonical Tone.js Sampler demo — `Tone.Sampler`
+ * pitch-shifts these to cover the full keyboard. Earlier code reused
+ * SALAMANDER_URLS here, which requested ~16 nonexistent casio files; the failed
+ * requests meant the Sampler's `onload` never fired and the UI hung forever on
+ * "Loading Electric Piano…". Keep this map to files that actually exist.
+ */
+const CASIO_URLS = {
+  A1: "A1.mp3",
+  A2: "A2.mp3",
+} as const;
+
 /* ─── Instrument Registry ─── */
 
 export const INSTRUMENTS: Record<SoundPresetId, InstrumentDefinition> = {
@@ -120,7 +137,7 @@ export const INSTRUMENTS: Record<SoundPresetId, InstrumentDefinition> = {
     label: "Piano",
     category: "keys",
     needsLoading: true,
-    create: ({ sustainMode, onLoaded }) => {
+    create: ({ sustainMode, onLoaded, onError }) => {
       const { compressor } = getEffectsChain();
       const sampler = new Tone.Sampler({
         urls: SALAMANDER_URLS,
@@ -128,12 +145,13 @@ export const INSTRUMENTS: Record<SoundPresetId, InstrumentDefinition> = {
         release: pianoRelease(sustainMode),
         volume: -6,
         onload: () => onLoaded?.(),
+        onerror: (err) => onError?.(err),
       });
       sampler.connect(compressor);
       sampler.connect(getPianoReverb());
       return sampler;
     },
-    createMelody: ({ onLoaded }) => {
+    createMelody: ({ onLoaded, onError }) => {
       const { compressor } = getEffectsChain();
       const sampler = new Tone.Sampler({
         urls: SALAMANDER_URLS,
@@ -141,6 +159,7 @@ export const INSTRUMENTS: Record<SoundPresetId, InstrumentDefinition> = {
         release: 1,
         volume: -4,
         onload: () => onLoaded?.(),
+        onerror: (err) => onError?.(err),
       });
       sampler.connect(compressor);
       sampler.connect(getPianoReverb());
@@ -154,24 +173,26 @@ export const INSTRUMENTS: Record<SoundPresetId, InstrumentDefinition> = {
     label: "Electric Piano",
     category: "keys",
     needsLoading: true,
-    create: ({ sustainMode, onLoaded }) => {
+    create: ({ sustainMode, onLoaded, onError }) => {
       const sampler = new Tone.Sampler({
-        urls: SALAMANDER_URLS,
+        urls: CASIO_URLS,
         baseUrl: "https://tonejs.github.io/audio/casio/",
         release: epRelease(sustainMode),
         volume: -8,
         onload: () => onLoaded?.(),
+        onerror: (err) => onError?.(err),
       });
       sampler.connect(getEPChorus());
       return sampler;
     },
-    createMelody: ({ onLoaded }) => {
+    createMelody: ({ onLoaded, onError }) => {
       const sampler = new Tone.Sampler({
-        urls: SALAMANDER_URLS,
+        urls: CASIO_URLS,
         baseUrl: "https://tonejs.github.io/audio/casio/",
         release: 0.8,
         volume: -6,
         onload: () => onLoaded?.(),
+        onerror: (err) => onError?.(err),
       });
       sampler.connect(getEPChorus());
       return sampler;

--- a/lib/audio/useInstrument.ts
+++ b/lib/audio/useInstrument.ts
@@ -1,0 +1,116 @@
+/**
+ * useInstrument — chord-instrument lifecycle with loading state and fallback.
+ *
+ * Centralises the synth lifecycle that the main progression page and the
+ * Sketchpad workspace previously duplicated. Beyond creating/disposing the
+ * instrument, it guarantees the UI can never get stuck on a "Loading…" state:
+ * if sample loading errors or takes too long, it disposes the failed
+ * instrument, falls back to the always-available Organ synth, and exposes a
+ * `loadError` label so callers can surface a brief notice.
+ */
+
+import { useEffect, useState } from "react";
+import type { SustainMode } from "./humanization";
+import {
+  INSTRUMENTS,
+  createSynthForPreset,
+  presetNeedsLoading,
+  type SoundPresetId,
+  type Synth,
+} from "./synthPresets";
+
+/** Instrument used when a sample-based preset fails to load. */
+const FALLBACK_PRESET: SoundPresetId = "organ";
+
+/** How long to wait for samples before treating the load as failed (ms). */
+const LOAD_TIMEOUT_MS = 10_000;
+
+export interface UseInstrumentOptions {
+  sustainMode?: SustainMode;
+  /**
+   * Caller-owned ref that receives the live instrument. Passing the ref in
+   * (rather than returning a new one) keeps it a stable `useRef` at the call
+   * site so React's exhaustive-deps lint stays happy.
+   */
+  synthRef: React.MutableRefObject<Synth | null>;
+}
+
+export interface UseInstrumentResult {
+  /** True while sample-based instruments download. */
+  isLoading: boolean;
+  /** Label of an instrument that failed to load (and was replaced), or null. */
+  loadError: string | null;
+  /** Dismiss the current load-error notice. */
+  dismissError: () => void;
+}
+
+export function useInstrument(
+  preset: SoundPresetId,
+  { sustainMode, synthRef }: UseInstrumentOptions,
+): UseInstrumentResult {
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let settled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    const clearTimer = () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+    };
+
+    /** Swap in the Organ synth and surface a notice naming the failed preset. */
+    const fallBack = () => {
+      if (cancelled || settled) return;
+      settled = true;
+      clearTimer();
+      if (synthRef.current) {
+        synthRef.current.releaseAll();
+        synthRef.current.dispose();
+        synthRef.current = null;
+      }
+      synthRef.current = createSynthForPreset(FALLBACK_PRESET, { sustainMode });
+      setIsLoading(false);
+      setLoadError(INSTRUMENTS[preset].label);
+    };
+
+    setIsLoading(presetNeedsLoading(preset));
+    setLoadError(null);
+
+    const synth = createSynthForPreset(preset, {
+      sustainMode,
+      onLoaded: () => {
+        if (cancelled || settled) return;
+        settled = true;
+        clearTimer();
+        setIsLoading(false);
+      },
+      onError: fallBack,
+    });
+    synthRef.current = synth;
+
+    if (presetNeedsLoading(preset)) {
+      timeoutId = setTimeout(fallBack, LOAD_TIMEOUT_MS);
+    }
+
+    return () => {
+      cancelled = true;
+      clearTimer();
+      if (synthRef.current) {
+        synthRef.current.releaseAll();
+        synthRef.current.dispose();
+        synthRef.current = null;
+      }
+    };
+  }, [preset, sustainMode, synthRef]);
+
+  return {
+    isLoading,
+    loadError,
+    dismissError: () => setLoadError(null),
+  };
+}


### PR DESCRIPTION
Electric Piano reused the 18-note Salamander sample map but pointed it at
the casio CDN folder, which only ships low-octave samples. The missing
files meant Tone.Sampler's onload never fired, leaving the UI stuck on
'Loading Electric Piano...' with the Play button permanently disabled and
no error surfaced.

- Give Electric Piano a correct casio sample map (CASIO_URLS); Tone.Sampler
  pitch-shifts to cover the keyboard.
- Add onerror handling to all sample-based instruments.
- Add a shared useInstrument hook (loading state + load timeout) that
  auto-falls back to the FM Organ synth and surfaces a dismissible notice
  if samples fail or stall, so playback never hangs. Replaces the duplicated
  synth lifecycle in the main page and Sketchpad workspace.
- Document the loading/fallback behavior in the README.