### PR TITLE
Fix progression editor UX: dismissable favorites, chord actions, scale-aware note editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Generate musically coherent chord progressions in any key and mode. Refine them 
   - **Sustain** — *Natural* lets notes ring slightly, *Off* tightens releases for clarity
   - **Soft Strum** — optional articulation that lightly rolls chord notes in (~18 ms apart), like a pianist easing into a chord; disabled by default
   - All playback settings persist across sessions via localStorage
-- **Interactive piano roll** — Click notes to preview, select and shift individual notes up/down by octave
-- **Chord locking** — Lock specific chords to preserve them while regenerating the rest
+- **Interactive piano roll** — Click a note to preview and select it, then nudge it up/down to the next in-key note with the on-screen ▲/▼ arrows (or Arrow keys). Desktop also supports mouse drag-and-drop for free chromatic placement
+- **Chord locking & substitution** — Select any chord to reveal a contextual action bar (Substitute · Lock · Revert) that works on both desktop and mobile
 - **MIDI export** — Download your progression as a standard MIDI file
 - **Voicing controls** — Choose voicing style (Tight, Balanced, Open) and density (Sparse 3-voice, Standard 4-voice, Rich 5-voice) via a collapsible panel
 - **Validated chord voicings** — Every generated chord is checked against a single source of truth (`getChordPitchClasses` in `lib/theory/chordSymbol.ts`), which derives the allowed pitch classes directly from the chord symbol (e.g. `D7` → D F♯ A C) across all 12 roots, keys, modes, and qualities. Voicings that would contain a note the symbol does not imply are logged and rebuilt from a safe voicing, so the notes you see and hear always match the chord label. Each voiced note also carries a harmonic role (chord tone, extension, alteration, bass), keeping chord tones distinct from non-chord tones
@@ -34,7 +34,7 @@ Generate musically coherent chord progressions in any key and mode. Refine them 
 Two complementary forms of control for refining generated progressions:
 
 - **Manual Chord Substitution** — Click any chord card to open a substitution panel with theory-approved alternatives. Options are grouped by category (diatonic, relative, dominant-function, tritone, modal mixture, inversion) with explanations of why each works. Preview before applying, and revert any time.
-- **Interactive Piano Roll Editing** — Double-click empty grid cells to add notes, double-click existing notes to remove them, and drag notes vertically to change pitch. Harmonia re-interprets the chord label in real time after edits. Source badges (Generated, Substituted, Edited) track the provenance of each chord. Reset any chord to its original state.
+- **Interactive Piano Roll Editing** — Double-click empty grid cells to add notes, double-click existing notes to remove them. Tap/click a note to select it, then move it up/down to the next in-key note with the ▲/▼ steppers or Arrow keys; on desktop you can also drag notes vertically for free chromatic placement. On mobile the roll scrolls naturally (drag is desktop-only), so editing stays precise. Harmonia re-interprets the chord label in real time after edits. Source badges (Generated, Substituted, Edited) track the provenance of each chord. Reset any chord to its original state.
 
 ### Harmonic Sketchpad
 
@@ -89,13 +89,13 @@ The piano and electric piano are **sampled** (Salamander Grand / Casio) and stre
 2. Set **complexity** (Simple → Altered) and number of chords
 3. Click **Chords** to create a progression
 4. Click any chord card to preview it, or hit **Play** to loop the full progression
-5. Use the piano roll to inspect voicings — click a note then **Cmd/Ctrl + Arrow Up/Down** to shift it by octave
-6. **Lock** chords you like, then regenerate to replace only the unlocked ones
+5. Use the piano roll to inspect voicings — click a note to select it, then use the **▲/▼ arrows** (or Arrow keys) to move it up/down to the next in-key note, or **Cmd/Ctrl + Arrow Up/Down** to shift it by a full octave. On desktop you can also drag notes with the mouse
+6. **Lock** chords you like (select a chord and use the **Lock** action), then regenerate to replace only the unlocked ones
 7. **Export MIDI** to bring your progression into a DAW
-8. Click the **substitute icon** on a chord card to browse theory-guided replacement options
+8. Select a chord and click **Substitute** in the action bar to browse theory-guided replacement options
 9. **Double-click** the piano roll grid to add or remove individual notes — chord labels update automatically
 10. Click **Melody** to generate a melody line — choose a style (Lyrical, Rhythmic, Arpeggio) and click **Melody** again for a new line. Use the **Audio** button in the action bar to mute/unmute chords and melody and to adjust playback feel — **Velocity**, **Humanize**, **Sustain**, and **Soft Strum** vs **Block Chord**
-11. Click **Save** to bookmark a progression to your favorites. Click **Favorites** to view, load, or remove saved progressions
+11. Click **Save** to bookmark a progression to your favorites. Click **Favorites** to view, load, or remove saved progressions, and the **✕** in the panel (or the Favorites button again) to hide it
 
 ### Harmonic Sketchpad
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -516,9 +516,9 @@
   border-bottom: 1px solid var(--border-subtle);
   position: relative;
   transition: background 0.08s;
-  /* Let the browser keep horizontal scrolling of the roll while we own
-     vertical gestures for touch drag-to-move (pitch editing). */
-  touch-action: pan-x;
+  /* Touch gestures scroll the roll/page freely — pitch drag is mouse/pen only.
+     Touch editing is tap-to-select plus the up/down steppers. */
+  touch-action: auto;
 }
 
 .note-cell.black-row {
@@ -576,10 +576,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  /* Vertical drag edits pitch; keep horizontal roll scrolling. pointer-events
+  /* Touch gestures scroll freely (melody drag is mouse/pen only). pointer-events
      is toggled per-bar from the component (auto when grabbable, none mid-drag
      so the underlying note cells receive the move events). */
-  touch-action: pan-x;
+  touch-action: auto;
   box-shadow: inset 0 1px 0 rgba(255,255,255,0.15);
 }
 .melody-overlay-bar.chord-tone {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,9 +3,9 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import * as Tone from "tone";
 import { motion, AnimatePresence } from "framer-motion";
-import { Play, Square, Download, Sparkles, Music, Lock, Unlock, LayoutDashboard, Shuffle, RotateCcw, ChevronDown, Heart, Trash2, Upload, VolumeX, Volume2, Settings2, Layers, Save, MoreVertical } from "lucide-react";
+import { Play, Square, Download, Sparkles, Music, Lock, Unlock, LayoutDashboard, Shuffle, RotateCcw, ChevronDown, Heart, Trash2, Upload, VolumeX, Volume2, Settings2, Layers, Save, MoreVertical, X } from "lucide-react";
 import Link from "next/link";
-import { useProgressionStore, COMPLEXITY_LABELS, type ComplexityLevel } from "@/lib/state/progressionStore";
+import { useProgressionStore, COMPLEXITY_LABELS, getScalePitchClasses, type ComplexityLevel } from "@/lib/state/progressionStore";
 import {
   usePlaybackSettingsStore,
   CHORD_VELOCITY_MIN,
@@ -811,10 +811,20 @@ export default function HarmoniaPage() {
         {/* ── Favorites Panel ── */}
         {showFavorites && (
           <section className="surface-section rounded-xl p-4">
-            <h3 className="text-sm font-semibold mb-3 flex items-center gap-2">
-              <Heart className="w-4 h-4 text-accent" />
-              Saved Progressions
-            </h3>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-semibold flex items-center gap-2">
+                <Heart className="w-4 h-4 text-accent" />
+                Saved Progressions
+              </h3>
+              <button
+                onClick={() => setShowFavorites(false)}
+                className="flex items-center justify-center w-7 h-7 rounded-full text-muted hover:text-foreground hover:bg-surface-muted transition-colors"
+                title="Hide saved progressions"
+                aria-label="Hide saved progressions"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
             {favorites.length === 0 ? (
               <p className="text-xs text-muted py-4 text-center">
                 No favorites yet. Save a progression to see it here.
@@ -1213,10 +1223,60 @@ export default function HarmoniaPage() {
 
                 {/* Voicing feedback removed and added to controls bar */}
 
+                {/* Contextual chord actions — lock / substitute / revert for the
+                    selected chord. The canonical surface on mobile (the per-card
+                    icons are hidden < sm) and a handy shortcut on desktop. */}
+                {selectedChordIndex !== null && currentProgression.chords[selectedChordIndex] && (
+                  <div className="mb-3 flex flex-wrap items-center gap-2 rounded-xl border border-border-subtle bg-surface-muted/50 px-3 py-2">
+                    <span className="text-xs text-muted">
+                      Chord{" "}
+                      <span className="font-semibold text-foreground">
+                        {currentProgression.chords[selectedChordIndex].symbol}
+                      </span>
+                    </span>
+                    <div className="flex items-center gap-1.5 ml-auto">
+                      <button
+                        onClick={() => openSubstitution(selectedChordIndex)}
+                        className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-border-subtle bg-surface hover:border-accent/50 hover:text-accent text-xs font-medium text-muted transition-colors"
+                        title="Change this chord"
+                      >
+                        <Shuffle className="w-3.5 h-3.5" />
+                        Substitute
+                      </button>
+                      <button
+                        onClick={() => toggleLock(selectedChordIndex)}
+                        className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border text-xs font-medium transition-colors ${
+                          currentProgression.chords[selectedChordIndex].isLocked
+                            ? "border-accent/40 bg-accent/10 text-accent"
+                            : "border-border-subtle bg-surface text-muted hover:border-accent/50 hover:text-accent"
+                        }`}
+                        title={currentProgression.chords[selectedChordIndex].isLocked ? "Unlock chord" : "Lock chord"}
+                      >
+                        {currentProgression.chords[selectedChordIndex].isLocked ? (
+                          <Lock className="w-3.5 h-3.5" />
+                        ) : (
+                          <Unlock className="w-3.5 h-3.5" />
+                        )}
+                        {currentProgression.chords[selectedChordIndex].isLocked ? "Locked" : "Lock"}
+                      </button>
+                      {originalChords.has(selectedChordIndex) && (
+                        <button
+                          onClick={() => revertChord(selectedChordIndex)}
+                          className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-border-subtle bg-surface hover:border-accent/50 hover:text-accent text-xs font-medium text-muted transition-colors"
+                          title="Revert to original"
+                        >
+                          <RotateCcw className="w-3.5 h-3.5" />
+                          Revert
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                )}
+
                 {/* Interactive Piano Roll */}
                 <p className="lg:hidden flex items-center gap-1.5 px-1 mb-1.5 text-[11px] text-muted/70">
                   <Music className="w-3 h-3 shrink-0 text-accent/60" />
-                  Piano roll — tap a note to hear it, drag to edit
+                  Piano roll — tap a note to hear it, then use the up/down arrows to move it
                 </p>
                 <div className="relative">
                 <InteractivePianoRoll
@@ -1232,6 +1292,7 @@ export default function HarmoniaPage() {
                   onRemoveNote={removeNote}
                   onMoveNote={moveNote}
                   onResetChord={resetChord}
+                  scalePitchClasses={getScalePitchClasses(rootKey, mode)}
                   chordSourceTypes={chordSourceTypes}
                   playheadRef={playheadRef}
                   melodyNotes={melodyEnabled && melody ? melody.notes : undefined}

--- a/components/creative/InteractivePianoRoll.tsx
+++ b/components/creative/InteractivePianoRoll.tsx
@@ -2,7 +2,7 @@
 
 import React, { useMemo, useState, useCallback, useRef, useEffect } from "react";
 import clsx from "clsx";
-import { Download, RotateCcw } from "lucide-react";
+import { Download, RotateCcw, ChevronUp, ChevronDown } from "lucide-react";
 import {
   isWhiteKey,
   midiToNoteName,
@@ -22,6 +22,8 @@ export type InteractivePianoRollProps = {
   onPlayNote?: (note: string) => void;
   onDeleteChord?: (index: number) => void;
   onShiftNote?: (chordIndex: number, midiNote: number, direction: "up" | "down") => void;
+  /** Pitch classes of the active key/scale; up/down steppers snap to these. */
+  scalePitchClasses?: PitchClass[];
   onSelectChord?: (index: number | null) => void;
   onExportMidi?: () => void;
   onAddNote?: (chordIndex: number, midi: number) => void;
@@ -109,6 +111,7 @@ export function InteractivePianoRoll({
   onPlayNote,
   onDeleteChord,
   onShiftNote,
+  scalePitchClasses,
   onSelectChord,
   onExportMidi,
   onAddNote,
@@ -242,10 +245,11 @@ export function InteractivePianoRoll({
     }
   }, [onAddNote, onRemoveNote, onPlayNote]);
 
-  // Drag handling for pitch changes. Uses pointer events so it works for mouse,
-  // touch and pen. Releasing the implicit pointer capture on pointerdown lets
-  // onPointerEnter fire on neighbouring cells while dragging on touch devices.
+  // Drag handling for pitch changes. Mouse/pen only — on touch a vertical drag
+  // is reserved for scrolling the roll (touch editing uses tap-to-select plus
+  // the up/down steppers instead, which keep notes in the scale).
   const handlePointerDown = useCallback((e: React.PointerEvent, midi: number, colIdx: number, hasNote: boolean) => {
+    if (e.pointerType === "touch") return;
     if (hasNote && onMoveNote) {
       if (e.currentTarget.hasPointerCapture?.(e.pointerId)) {
         e.currentTarget.releasePointerCapture(e.pointerId);
@@ -270,6 +274,37 @@ export function InteractivePianoRoll({
     setDragStart(null);
     setDraggingMelodyId(null);
   }, []);
+
+  // Move the selected note to the next/previous pitch in the active scale,
+  // skipping pitches already used by the chord. Works the same on desktop and
+  // touch — the intuitive "keep it in key" up/down control. Falls back to a
+  // chromatic step if no scale is supplied.
+  const stepSelectedNote = useCallback((direction: "up" | "down") => {
+    if (!selectedNote || !onMoveNote) return;
+    const { chordIndex, midi } = selectedNote;
+    const occupied = new Set(chords[chordIndex]?.midiNotes ?? []);
+    const scaleSet = scalePitchClasses && scalePitchClasses.length > 0
+      ? new Set<PitchClass>(scalePitchClasses)
+      : null;
+    const delta = direction === "up" ? 1 : -1;
+    const limit = direction === "up" ? 108 : 21;
+
+    let candidate = midi + delta;
+    while (direction === "up" ? candidate <= limit : candidate >= limit) {
+      const inScale = !scaleSet || scaleSet.has(midiToPitchClass(candidate));
+      if (inScale && !occupied.has(candidate)) {
+        onMoveNote(chordIndex, midi, candidate);
+        setSelectedNote({ chordIndex, midi: candidate });
+        if (onPlayNote) {
+          onPlayNote(midiToNoteName(candidate));
+          setFlashingNote(candidate);
+          setTimeout(() => setFlashingNote(null), 250);
+        }
+        return;
+      }
+      candidate += delta;
+    }
+  }, [selectedNote, onMoveNote, chords, scalePitchClasses, onPlayNote]);
 
   const isDraggingActive = isDragging || draggingMelodyId !== null;
   useEffect(() => {
@@ -320,11 +355,21 @@ export function InteractivePianoRoll({
         }
         return;
       }
+
+      // Plain Arrow Up/Down steps the selected note to the next in-scale pitch.
+      if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+        if (selectedNote) {
+          if ((e.target as HTMLElement)?.tagName === "INPUT" || (e.target as HTMLElement)?.tagName === "SELECT") return;
+          e.preventDefault();
+          stepSelectedNote(e.key === "ArrowUp" ? "up" : "down");
+        }
+        return;
+      }
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [selectedIndex, selectedNote, onDeleteChord, onShiftNote, onSelectChord, onRemoveNote]);
+  }, [selectedIndex, selectedNote, onDeleteChord, onShiftNote, onSelectChord, onRemoveNote, stepSelectedNote]);
 
   const selectedNoteLabel = useMemo(() => {
     if (!selectedNote) return null;
@@ -333,6 +378,35 @@ export function InteractivePianoRoll({
 
   return (
     <div className="piano-roll-section">
+      {/* Selected-note stepper: tap a note, then nudge it up/down within the
+          key. The primary editing control on touch (where drag is disabled). */}
+      {selectedNote && (
+        <div className="flex items-center justify-center gap-2 mb-2">
+          <span className="text-[11px] text-muted">
+            Note <span className="font-semibold text-foreground font-mono">{selectedNoteLabel}</span>
+          </span>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => stepSelectedNote("up")}
+              className="flex items-center justify-center w-10 h-10 rounded-lg border border-border-subtle bg-surface hover:bg-surface-muted hover:border-accent/50 text-muted hover:text-accent transition-colors"
+              title="Move note up (in key)"
+              aria-label="Move note up"
+            >
+              <ChevronUp className="w-5 h-5" />
+            </button>
+            <button
+              type="button"
+              onClick={() => stepSelectedNote("down")}
+              className="flex items-center justify-center w-10 h-10 rounded-lg border border-border-subtle bg-surface hover:bg-surface-muted hover:border-accent/50 text-muted hover:text-accent transition-colors"
+              title="Move note down (in key)"
+              aria-label="Move note down"
+            >
+              <ChevronDown className="w-5 h-5" />
+            </button>
+          </div>
+        </div>
+      )}
       <div className="piano-roll-wrap">
         {/* LEFT PIANO KEYBOARD */}
         <div className="piano-keys">
@@ -457,6 +531,7 @@ export function InteractivePianoRoll({
                       <div
                         key={mn.id}
                         onPointerDown={(e) => {
+                          if (e.pointerType === "touch") return;
                           e.stopPropagation();
                           if (onMoveMelodyNote) {
                             if (e.currentTarget.hasPointerCapture?.(e.pointerId)) {

--- a/lib/state/progressionStore.ts
+++ b/lib/state/progressionStore.ts
@@ -13,6 +13,21 @@ import type { Melody, MelodyNote, MelodyStyle } from "../music/generators/melody
 import { getScaleDefinition } from "../theory/scale";
 import type { ScaleType } from "../theory/types";
 
+const MODE_TO_SCALE: Record<Mode, ScaleType> = {
+    ionian: "major",
+    aeolian: "natural_minor",
+    dorian: "dorian",
+    mixolydian: "mixolydian",
+    phrygian: "phrygian",
+};
+
+/** Pitch classes of the active key/scale for the given root + mode. */
+export function getScalePitchClasses(rootKey: string, mode: Mode): PitchClass[] {
+    const rootPC = (normalizeToPitchClass(rootKey) || "C") as PitchClass;
+    const scaleType = MODE_TO_SCALE[mode] ?? "major";
+    return getScaleDefinition(rootPC, scaleType).pitchClasses;
+}
+
 export type ComplexityLevel = 1 | 2 | 3 | 4;
 
 export const COMPLEXITY_LABELS: Record<ComplexityLevel, string> = {
@@ -592,16 +607,7 @@ export const useProgressionStore = create<ProgressionState>((set, get) => ({
         const { currentProgression, rootKey, mode, melodyStyle } = get();
         if (!currentProgression) return;
 
-        const rootPC = (normalizeToPitchClass(rootKey) || "C") as PitchClass;
-        const MODE_TO_SCALE: Record<Mode, ScaleType> = {
-            ionian: "major",
-            aeolian: "natural_minor",
-            dorian: "dorian",
-            mixolydian: "mixolydian",
-            phrygian: "phrygian",
-        };
-        const scaleType = MODE_TO_SCALE[mode] ?? "major";
-        const scale = getScaleDefinition(rootPC, scaleType);
+        const scalePitchClasses = getScalePitchClasses(rootKey, mode);
 
         const chords = currentProgression.chords.map((c) => ({
             midiNotes: c.midiNotes ?? [],
@@ -611,7 +617,7 @@ export const useProgressionStore = create<ProgressionState>((set, get) => ({
         }));
 
         const melody = generateMelody({
-            scalePitchClasses: scale.pitchClasses,
+            scalePitchClasses,
             chords,
             style: melodyStyle,
             octave: 5,


### PR DESCRIPTION
- Favorites: add a close (X) button to the Saved Progressions panel so it
  can be hidden without hunting for the header toggle.
- Lock/Substitute: surface lock, substitute, and revert in a contextual
  action bar shown when a chord is selected — works on mobile (where the
  per-card icons are hidden < sm) and as a desktop shortcut.
- Note editor: disable vertical drag on touch so the roll scrolls normally;
  add up/down steppers (and plain Arrow keys) that move the selected note to
  the next in-key pitch. Desktop keeps mouse drag for free chromatic edits.
- Extract/reuse getScalePitchClasses from the store for scale snapping.

Updates README accordingly.