### PR TITLE
Add audio engine assessment and hybrid playback proposal

### DIFF
--- a/AUDIO_ENGINE_ASSESSMENT.md
+++ b/AUDIO_ENGINE_ASSESSMENT.md
@@ -1,6 +1,14 @@
 # Harmonia Audio Engine Assessment
 
-Assessment of the current playback stack and a proposal for a two-tier (Lightweight / High-Quality) audio architecture. **No implementation has been done — this is a recommendation document.**
+Assessment of the current playback stack and a proposal for a two-tier (Lightweight / High-Quality) audio architecture.
+
+> **Implementation status:** Option D was approved and Phases 1–3 are implemented
+> (persisted `audioSettingsStore`, lightweight synth tier — Soft Keys, Filtered Saw,
+> FM Electric Piano, synth piano — quality modes with background sample loading,
+> hot-swap, and timbre-preserving fallback). Phase 4 (self-hosted samples + a better
+> EP sample set) and Phase 5 (Tone.js code-splitting) remain follow-ups; samples
+> still stream from the Tone.js CDN, and sample assets could not be mirrored from
+> this environment (network policy blocks `tonejs.github.io`).
 
 ---
 

--- a/AUDIO_ENGINE_ASSESSMENT.md
+++ b/AUDIO_ENGINE_ASSESSMENT.md
@@ -1,0 +1,289 @@
+# Harmonia Audio Engine Assessment
+
+Assessment of the current playback stack and a proposal for a two-tier (Lightweight / High-Quality) audio architecture. **No implementation has been done — this is a recommendation document.**
+
+---
+
+## Current Architecture
+
+### Libraries
+
+| Library | Version | Role |
+|---|---|---|
+| `tone` | ^15.1.22 | All synthesis, sampling, scheduling, effects |
+| `@tonejs/midi` | ^2.0.28 | MIDI export only (no playback role) |
+| Raw Web Audio API | — | `lib/audio/playChordFromPitchClasses.ts` (sine-wave chord/scale preview; only referenced by `_deferred/` practice components, dead in the live app) |
+
+### Instrument layer — `lib/audio/synthPresets.ts`
+
+The app already has a real instrument abstraction: an `INSTRUMENTS` registry of `InstrumentDefinition` entries (`id`, `label`, `category`, `needsLoading`, `create`, `createMelody`). Call sites go through `createSynthForPreset()` / `createMelodySynthForPreset()` and never touch Tone classes directly. Three instruments exist today:
+
+1. **Piano** — `Tone.Sampler` with 18 Salamander Grand mp3s loaded from `https://tonejs.github.io/audio/salamander/` (CDN, GitHub Pages). Routed through a compressor + dedicated 2.5s reverb.
+2. **Electric Piano** — `Tone.Sampler` with only **2** Casio mp3s (`A1`, `A2`) from `https://tonejs.github.io/audio/casio/`, pitch-shifted across the entire keyboard, through a chorus.
+3. **Organ** — `Tone.PolySynth(Tone.FMSynth)`, sine-on-sine FM. The only zero-download instrument, and therefore the universal fallback.
+
+A shared master chain (`Compressor → Reverb → Limiter(-3dB) → Destination`) is built lazily as singletons.
+
+### Lifecycle & fallback — `lib/audio/useInstrument.ts`
+
+A shared hook (used by both `app/page.tsx` and `components/sketchpad/Workspace.tsx`) creates/disposes the instrument, exposes `isLoading` / `loadError`, and on sample-load error **or a 10s timeout** disposes the sampler and swaps in the Organ synth with a dismissible notice ("Piano couldn't load — using Organ instead."). The Play button is disabled and shows a spinner while samples download.
+
+### Scheduling — `app/page.tsx` (~lines 190–345) and `Workspace.tsx`
+
+- Chords are scheduled on the **Tone.js Transport** using musical time strings (`bars:quarters:sixteenths`) derived from each chord's `durationClass` (full/half/quarter/eighth → 4/2/1/0.5 beats).
+- Transport `loop`/`loopStart`/`loopEnd` give sample-accurate looping; BPM is synced to the store.
+- UI highlight sync uses `Tone.getDraw().schedule()`; the playhead is a `requestAnimationFrame` loop reading `transport.seconds`.
+- Melody notes are scheduled the same way on a second (melody) instrument instance.
+- `await Tone.start()` is called inside user-gesture handlers (Play, Generate, sketchpad play/chord-click) — the standard iOS/Chrome autoplay unlock.
+
+### Velocity, duration, humanization — `lib/audio/humanization.ts`
+
+A pure, Tone-free module converts a chord's notes into `NoteEvent[]` (`note`, `velocity`, `timeOffset`): bounded velocity variation (±0.12 max), timing jitter (±12ms max), strum (~18ms steps), and tempo-aware arpeggio spread. Playback reads live settings via `usePlaybackSettingsStore.getState()` so slider changes apply mid-loop. This module is well-designed and engine-agnostic — it survives any engine change unmodified.
+
+### Settings & persistence
+
+- `lib/state/playbackSettingsStore.ts` (Zustand + `persist` → localStorage key `harmonia-playback-settings`): velocity, humanize, sustain, playback style. **Persisted.**
+- **Instrument choice is NOT persisted** — it's plain `useState<SoundPresetId>("piano")` duplicated independently in `app/page.tsx:141` and `Workspace.tsx:35`. It resets to Piano on every reload, and the main page and Sketchpad can disagree.
+
+### Settings UX today
+
+Everything lives in a popover behind a small volume icon in the action bar: instrument `<select>`, chord/melody mute, velocity, humanize, sustain, style. There is no concept of audio quality anywhere in the UI.
+
+---
+
+## Current Limitations
+
+1. **Heavy default load, no lightweight path.** Piano (sampled) is the hard-coded default, so ~18 Salamander mp3s (~2–4 MB) download from a third-party CDN **on every fresh page load**, and Play is disabled until they finish. On slow connections the user waits up to 10s and is then dumped to Organ.
+2. **Fallback changes timbre drastically.** Sampled piano failing → FM organ. Functional, but jarring; the fallback doesn't try to sound like the instrument the user picked.
+3. **Electric Piano quality is poor.** Two Casio samples stretched over 7+ octaves sounds thin and detuned at the extremes — far from a "warm electric piano." (A code comment confirms this map was reduced to 2 files just to stop a loading hang.)
+4. **No pad / soft-synth / filtered-saw option at all.** The brief's "soft synth pads" and "mellow polysynth" categories don't exist; Organ is the only synth voice.
+5. **Third-party CDN dependency.** `tonejs.github.io` is GitHub Pages: no SLA, no versioning, can be blocked on corporate/school networks, and breaks entirely offline. There is no service worker, so nothing audio works offline today.
+6. **Instrument preference isn't persisted** and is duplicated per page (see above).
+7. **Double sample download per preset.** Enabling melody creates a *second* `Tone.Sampler` with the same URLs (`createMelodySynthForPreset`). HTTP cache usually saves the network hit, but decode + memory cost is doubled, which matters on low-end mobile.
+8. **Tone.js is in the main client bundle.** `app/page.tsx` and `Workspace.tsx` statically `import * as Tone from "tone"` (~150–200 KB gzipped). It is not code-split or deferred, and it's loaded even for users who never press Play.
+9. **Mobile edge cases.** `Tone.start()` on gesture is handled, but there's no `visibilitychange`/interruption recovery (iOS suspends the AudioContext when backgrounded or on a phone call), and the 10ms `setTimeout` in `handleChordClick` is a code smell for release/attack sequencing.
+10. **Effects singletons never adapt.** Reverb decay/wet, compressor, chorus are fixed; `Tone.Reverb` also generates its impulse response asynchronously at startup (small one-time CPU cost).
+
+What's genuinely **good** and worth keeping: the instrument registry abstraction, the `useInstrument` loading/timeout/fallback pattern, the pure humanization module, Transport-based musical-time scheduling with `Draw` sync, and the persisted playback-settings store. The architecture already supports instrument abstraction and async (lazy) sample loading — the missing pieces are quality tiers, better sounds, persistence, and graceful degradation.
+
+---
+
+## Sound Quality Goals
+
+Target palette (from the brief):
+
+| Target sound | Today | Gap |
+|---|---|---|
+| Lush acoustic piano | Salamander sampler (decent) | No velocity layers; CDN fragility; blocking load |
+| Warm electric piano | 2-sample Casio (weak) | Needs a real EP sample set (Rhodes-style, ~10+ zones) |
+| Soft synth pads / keys | — | New lightweight synth voice |
+| Filtered saw / mellow polysynth | — | New lightweight synth voice |
+
+"Musical and polished" is achievable in *both* tiers: a well-designed filtered-saw PolySynth with chorus + reverb sounds intentional and warm; the lightweight tier should never feel like a punishment.
+
+---
+
+## Option A: Improve Existing Synth Engine
+
+**Description.** Stay 100% synthesis. Replace/augment the Organ with carefully designed Tone.js patches: a "Soft Keys" voice (triangle/sine PolySynth, gentle attack, lowpass, chorus), a "Filtered Saw" pad (`Tone.PolySynth(Tone.Synth, {oscillator: "fatsawtooth"})` → `Tone.Filter` lowpass with envelope → chorus → reverb), an FM electric-piano emulation (classic DX7-style FM patch), and an additive/FM piano approximation. Tune the master chain per voice.
+
+- **Pros**
+  - Zero asset downloads; instant startup everywhere, including offline.
+  - No CDN, no loading states, no fallback complexity.
+  - Smallest possible scope; all changes confined to `synthPresets.ts`.
+  - Pads and filtered saw genuinely sound *good* as synthesis — these two targets are best served by synths anyway.
+- **Cons**
+  - Acoustic piano via synthesis will never sound "lush" — this is the hard ceiling. FM electric piano can get to "pleasant" but not "warm vintage."
+  - Doesn't deliver the headline goal (inspiring realistic piano).
+- **Estimated effort:** 2–4 days (sound design is the bulk).
+- **Bundle/load impact:** ~0. No new bytes.
+- **Sound quality potential:** Medium for EP/pads/saw, **low for acoustic piano**.
+
+## Option B: Tone.js Sampler With Lazy-Loaded Samples
+
+**Description.** Double down on what already exists. Keep `Tone.Sampler`, but: (1) self-host a curated, compressed sample set (Salamander subset for piano; a properly multi-sampled EP such as a Rhodes set converted from a permissively-licensed SoundFont/FreePats source) in `public/samples/` or a first-party CDN (the app already deploys to Vercel, which serves static assets from its edge CDN); (2) load samples **lazily on instrument selection**, never blocking page load; (3) progressively load — fetch the 6–8 mid-range zones first so playback can start in ~1s, then fill in outer octaves; (4) share one sampler between chord and melody roles.
+
+- **Pros**
+  - Best realism per engineering hour; `Tone.Sampler` already handles pitch-shifting, polyphony, and integrates natively with the existing Transport scheduling and humanization.
+  - Minimal architectural change — extends the existing registry/`useInstrument` pattern.
+  - Self-hosting removes the third-party CDN risk and enables offline caching later.
+- **Cons**
+  - Samples are still megabytes; without a synth tier, slow networks still mean waiting or falling back to a mismatched sound.
+  - Sample curation/licensing work (Salamander is CC-BY 3.0 — fine with attribution; EP set needs vetting).
+  - Repo/deploy size grows (~4–8 MB of audio assets).
+- **Estimated effort:** 4–6 days.
+- **Bundle/load impact:** JS unchanged; ~2–4 MB lazy audio per sampled instrument (mp3/ogg, loaded only when selected; ~300–600 KB for the "playable fast" progressive first wave).
+- **Sound quality potential:** **High** for piano/EP.
+
+## Option C: SoundFont / WebAudioFont Approach
+
+**Description.** Replace or augment playback with General-MIDI-style instrument banks: WebAudioFont (instruments as ~100–600 KB JS files with its own player), or `soundfont-player`/`smplr` loading FluidR3/FatBoy/MusyngKite banks.
+
+- **Pros**
+  - Hundreds of instruments instantly available; small per-instrument payloads.
+  - Battle-tested GM sounds; lazy loading is the default model.
+- **Cons**
+  - **GM sound quality is dated** — typically *worse* than the current Salamander piano. This moves the headline sound backwards.
+  - WebAudioFont and soundfont players have their **own scheduling/envelope APIs** that don't plug into `Tone.Transport`, `triggerAttackRelease`, or the humanization event model — the scheduler in `page.tsx`/`Workspace.tsx` would need an adapter layer or rewrite.
+  - Two audio paradigms in one codebase = long-term maintenance drag.
+- **Estimated effort:** 5–8 days (mostly integration/adapter work).
+- **Bundle/load impact:** +20–40 KB player JS; 100–600 KB per instrument, lazy.
+- **Sound quality potential:** Medium-low (GM-grade). Good breadth, weak depth.
+
+## Option D: Hybrid Engine (Synth tier + Lazy Sampler tier)
+
+**Description.** Combine A and B behind the existing registry, organized as explicit quality tiers:
+
+- **Lightweight tier (synthesis, instant, always works):** Soft Keys, Filtered Saw pad, FM Electric Piano, FM/additive Piano approximation, Organ. Zero downloads.
+- **High-Quality tier (Tone.Sampler, lazy, self-hosted):** Lush Piano (Salamander), Warm EP (real multi-sample set), optionally a sampled pad later.
+- Every HQ instrument declares a **lightweight twin** (`fallbackId`), so degradation keeps the timbre family (sampled piano → synth piano, not organ).
+- An `audioSettingsStore` (persisted) holds quality mode + instrument; both pages consume it.
+
+- **Pros**
+  - Delivers all four target sounds at the best quality each can achieve.
+  - Instant, reliable default; HQ is opt-in/auto-upgrade, never blocking.
+  - Builds directly on the existing registry, `useInstrument`, humanization, and Transport scheduling — no rewrite, no second audio paradigm.
+  - Future instruments slot in as registry entries in either tier.
+- **Cons**
+  - Largest single scope (though it decomposes into safe phases — see plan).
+  - Sound-design and sample-curation work both required.
+  - More UI states to design (per-instrument loading, quality badges, fallback notices).
+- **Estimated effort:** 7–10 days total across phases; each phase ships independently.
+- **Bundle/load impact:** JS roughly unchanged (optionally −150 KB initial if Tone.js is dynamically imported in a later phase); HQ audio is 100% lazy.
+- **Sound quality potential:** **High** — and the floor (lightweight mode) also rises substantially.
+
+---
+
+## Recommended Path
+
+**Option D (Hybrid), implemented as incremental phases on top of the existing registry.**
+
+Why: the codebase is already ~60% of the way there — it has an instrument abstraction, async sample loading with timeout/fallback, loading UI, and engine-agnostic humanization. What's missing is exactly what the hybrid adds: a pleasant always-instant synth tier, a properly-sourced HQ tier that loads lazily instead of blocking page load, persistence, and timbre-preserving fallback. Options A and B are each *half* of D; C would be a paradigm fork with a quality ceiling below what Harmonia already has.
+
+Priority alignment: great sound (HQ sampler tier) ✓, fast initial load (synth default + lazy samples) ✓, reliable mobile (synth tier always works; samples optional) ✓, simple UX (one quality toggle + one instrument picker) ✓, maintainable (single registry, single scheduler) ✓, expandable (new instrument = one registry entry) ✓.
+
+---
+
+## Proposed Audio Mode Architecture
+
+```
+                    audioSettingsStore (persisted)
+                    quality: "lightweight" | "high" (+ "auto" upgrade flag)
+                    instrumentId, defaultQuality
+                              │
+                       useInstrument(instrumentId, quality)
+                              │
+              INSTRUMENTS registry (extends existing InstrumentDefinition)
+              ┌──────────────────────────┬────────────────────────────────┐
+              │ Lightweight (synth)      │ High-Quality (Tone.Sampler)    │
+              │ needsLoading: false      │ needsLoading: true             │
+              │ • Soft Keys              │ • Lush Piano   (fallback:      │
+              │ • Filtered Saw           │     Soft Keys / synth piano)   │
+              │ • Electric Piano (FM)    │ • Warm EP      (fallback:      │
+              │ • Organ                  │     FM Electric Piano)         │
+              └──────────────────────────┴────────────────────────────────┘
+                              │
+        Existing, unchanged: humanization → Transport.schedule → triggerAttackRelease
+```
+
+Key behaviors:
+
+1. **Instrument identity is separate from quality.** The user picks a *sound* ("Lush Piano", "Electric Piano", "Soft Keys", "Filtered Saw"); the quality mode decides whether the sampled or synth realization is used where both exist. Each `InstrumentDefinition` gains `tier: "lightweight" | "high"` and optional `fallbackId`.
+2. **Lightweight is the cold-start default.** First-ever visit plays instantly on synthesis. If the user's persisted default is High Quality (or "auto-upgrade" is on), the sampler loads **in the background while the synth twin is already playable**; when `onload` fires, the engine hot-swaps at the next scheduled chord boundary. The Play button is never disabled by sample loading again.
+3. **Fallback preserves timbre.** Sampler error/timeout → the instrument's `fallbackId` twin (not Organ), plus the existing dismissible notice, now worded: "High-quality Piano couldn't load — playing the lightweight version."
+4. **One instrument instance per role, shared sample buffers.** Chord and melody instruments for the same sampled preset should share `Tone.ToneAudioBuffers` (or simply one Sampler) to halve memory/decoding.
+5. **Scheduling, humanization, looping, Draw sync: unchanged.** The hot-swap only replaces what `synthRef.current` points to.
+
+## Proposed User Settings UX
+
+Keep everything in the existing audio popover (volume icon in the action bar) — it's already the discoverable home for sound settings — but restructure it:
+
+```
+┌─ Sound ────────────────────────────────┐
+│ Instrument:  [♪ Lush Piano        ▾]   │   ← grouped select: "Keys", "Synths"
+│              (spinner + "loading…"     │
+│               inline while HQ loads)   │
+│                                        │
+│ Audio quality:  ( Lightweight | High ) │   ← segmented control
+│   "Lightweight starts instantly.       │
+│    High Quality downloads real         │
+│    instrument samples (~3 MB)."        │   ← one-line plain-language hint
+│                                        │
+│ ☑ Use high quality when available      │   ← auto-upgrade: start light,
+│                                        │     switch when samples are ready
+├─ Mute: Chords / Melody (unchanged) ────┤
+├─ Playback: velocity, humanize, sustain,│
+│            style (unchanged)           │
+└────────────────────────────────────────┘
+```
+
+- **Selecting quality mode:** the segmented control switches immediately; switching to High shows the inline loading state on the instrument row and keeps playing the lightweight twin until ready.
+- **Default quality:** whatever the user last selected *is* the persisted default (no separate "default" dropdown — one less concept; the "use high quality when available" checkbox covers the "prefer HQ but don't block" case). If a distinct default control is desired later it's a one-line store addition.
+- **Instrument picker:** options labeled plainly (Lush Piano, Electric Piano, Soft Keys, Filtered Saw, Organ); HQ-capable entries get a small "HQ" badge when high quality is active.
+- **Loading state:** inline spinner + label in the popover row, plus the existing subtle notice area above the action bar. Play is never disabled.
+- **Failure:** automatic fallback to the lightweight twin + dismissible amber notice (existing pattern, re-worded). A "Retry" link re-attempts the sampler load.
+- **Sketchpad** consumes the same store, so the choice follows the user across pages.
+
+## Persistence Plan
+
+Add `lib/state/audioSettingsStore.ts` mirroring the existing `playbackSettingsStore` pattern (Zustand + `persist`, localStorage key `harmonia-audio-settings`):
+
+```ts
+{ instrumentId: "lush-piano", quality: "lightweight" | "high",
+  autoUpgrade: boolean }   // defaults: soft instrument, "lightweight", true
+```
+
+Both `app/page.tsx` and `Workspace.tsx` drop their local `useState` and read this store — fixing the no-persistence and duplicated-state issues in one move. Migration: none needed (instrument was never persisted); keep `harmonia-playback-settings` untouched.
+
+## Fallback Plan
+
+Trigger conditions (all already detected by `useInstrument`): Sampler `onerror`, or load exceeding the timeout (keep 10s; consider 15s on detected slow connections via `navigator.connection`).
+
+1. Dispose the failed sampler (existing behavior).
+2. Instantiate the instrument's `fallbackId` lightweight twin — *not* Organ — so the music keeps the same character.
+3. Surface the existing dismissible notice with a Retry affordance.
+4. Record the failure in-memory for the session; `autoUpgrade` stops re-attempting after 2 failures to avoid background-retry loops on captive/blocked networks.
+5. If even synth creation throws (no Web Audio at all), keep the current behavior: controls disabled, console warning — this is the SSR/ancient-browser case and is already guarded.
+
+Offline: lightweight mode works fully offline once the JS is cached. HQ samples self-hosted under `public/samples/` become cacheable by a future service worker (out of scope here, but the self-hosting choice is what makes it possible).
+
+## Implementation Plan
+
+Each phase is independently shippable and low-risk:
+
+1. **Phase 1 — Settings foundation (no sound change).** Add `audioSettingsStore` (persisted); wire `page.tsx` + `Workspace.tsx` to it; instrument choice now persists and is shared. *(~½ day)*
+2. **Phase 2 — Lightweight tier sound design.** Add Soft Keys and Filtered Saw `InstrumentDefinition`s (synth, `needsLoading: false`); add an FM electric-piano synth voice; tune per-voice effects sends. Make a lightweight voice the cold-start default. *(~2 days, mostly ear time)*
+3. **Phase 3 — Quality modes + timbre-preserving fallback.** Add `tier`/`fallbackId` to the registry; add the quality segmented control + explainer + auto-upgrade checkbox to the popover; change `useInstrument` to fall back to the twin; hot-swap on background load. Play button no longer disabled while loading. *(~2 days)*
+4. **Phase 4 — HQ sample quality + self-hosting.** Move Salamander subset to first-party hosting (`public/samples/` on Vercel's CDN); source and integrate a real multi-sampled EP (license-vetted); progressive loading (mid-octaves first); share buffers between chord/melody roles. *(~2–3 days)*
+5. **Phase 5 (optional) — Bundle hygiene.** Dynamically import a thin `audioEngine` module (which itself imports Tone) so Tone.js leaves the initial bundle; preload on first pointer-down. *(~1 day; measurable LCP/TTI win, zero UX change)*
+
+## Files Likely to Change
+
+| File | Why |
+|---|---|
+| `lib/audio/synthPresets.ts` | New instrument entries (Soft Keys, Filtered Saw, FM EP), `tier`/`fallbackId` fields, EP sample map replacement, self-hosted `baseUrl`s |
+| `lib/audio/useInstrument.ts` | Quality-aware creation, twin fallback, background load + hot-swap, retry |
+| `lib/state/audioSettingsStore.ts` | **New** — persisted instrument + quality + auto-upgrade |
+| `app/page.tsx` | Drop local `soundPreset` state; popover UI: quality control, explainer, badges, loading row; un-disable Play during loads |
+| `components/sketchpad/Workspace.tsx` | Same store consumption; remove duplicated state |
+| `public/samples/**` | **New** — self-hosted piano/EP sample assets |
+| `lib/audio/__tests__/` | Tests for store, registry tiers, fallback logic |
+| `README.md` | Document the new audio modes (per project convention) |
+
+## Testing Plan
+
+- **Unit (vitest, happy-dom — existing setup):** `audioSettingsStore` persistence/defaults/clamping; registry invariants (every HQ instrument has a valid `fallbackId`; every `SoundPresetId` resolves); humanization regression suite already exists and must stay green; fallback state machine in `useInstrument` with mocked Sampler (`onload`/`onerror`/timeout paths — fake timers).
+- **Integration:** render the page with a mocked Tone module; assert Play is enabled during HQ load, hot-swap happens on `onload`, twin fallback + notice on error, settings survive a simulated reload (localStorage).
+- **Manual browser matrix:** Chrome/Firefox/Edge desktop, **Safari desktop** (stricter Web Audio), with DevTools network throttling (Slow 3G: verify instant lightweight playback + background HQ upgrade; Offline: verify lightweight works, HQ falls back gracefully).
+- **Mobile:** iOS Safari — first-tap audio unlock, silent-switch behavior, backgrounding/return (context suspension), HQ load over cellular; Android Chrome — same pass; verify memory stability when toggling instruments repeatedly (sampler disposal).
+- **Audio QA checklist:** each instrument auditioned across C2–C6, block/strum/arpeggio styles, velocity extremes, sustained loop for 5+ minutes (no clipping at limiter, no envelope clicks, no chorus/reverb buildup).
+
+## Open Questions
+
+1. **Sample hosting:** self-host in `public/` (repo grows ~4–8 MB; served by Vercel's edge CDN — recommended) vs. external object storage/CDN? Any Vercel bandwidth budget concerns?
+2. **Cold-start default sound:** Soft Keys (safest, prettiest synth) or the synth piano twin (closer to current default timbre)? Recommendation: Soft Keys.
+3. **`autoUpgrade` default ON?** Recommended yes on desktop; consider defaulting OFF when `navigator.connection.saveData` is set or on detected 2G/3G.
+4. **EP sample source:** needs a license-vetted multi-sampled Rhodes/Wurli set (FreePats, permissive SoundFont extraction, or a purchased/CC0 set). Decision needed before Phase 4. Salamander piano is CC-BY 3.0 — attribution should be added to the README either way (it's in production use today).
+5. **Keep "Organ"?** It's currently fallback + a selectable preset. Proposal: keep as a lightweight instrument, retire it as the universal fallback.
+6. **Is Phase 5 (Tone.js code-splitting) worth it now**, or defer until there's a perf budget exercise?
+7. **Melody voice:** should melody default to the same instrument as chords (current behavior) or get its own picker later? Proposal: keep shared for now; the registry already supports divergence.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,9 @@ npm run lint      # Run ESLint
 | `lib/theory/` | Core music theory: scales, chords, MIDI, pitch classes |
 | `lib/music/generators/advanced/` | Advanced progression generation pipeline |
 | `lib/music/generators/melody/` | Phrase-based melody engine (phrase plan, contour, motifs, moods, ornaments, scoring) |
-| `lib/audio/synthPresets.ts` | Shared synth factory: Piano, Electric Piano, Organ |
+| `lib/audio/instrumentCatalog.ts` | Tone-free instrument metadata (ids, labels, quality tiers) |
+| `lib/audio/synthPresets.ts` | Instrument registry: lightweight synth + high-quality sampler realizations per instrument |
+| `lib/state/audioSettingsStore.ts` | Persisted audio settings (instrument, Lightweight/High quality mode) |
 | `components/creative/` | SubstitutionPanel, MutationControls, InteractivePianoRoll |
 | `components/progression/` | VerticalPianoRoll (original read-only version) |
 

--- a/README.md
+++ b/README.md
@@ -80,11 +80,18 @@ The favicon is an SVG (`app/icon.svg`) for crisp browser tabs. Because iOS Safar
 
 ### Audio architecture & performance
 
-Instruments are defined in a small registry (`lib/audio/synthPresets.ts`) so new instruments (Strings, Pad, …) can be added as a single entry without touching playback code. Playback humanization is a pure, dependency-free module (`lib/audio/humanization.ts`) that the scheduler applies per note.
+Playback has two quality modes, selectable (and persisted) from the **Audio** menu:
 
-The piano and electric piano are **sampled** (Salamander Grand / Casio) and stream from the Tone.js CDN — humanization adds **no bundle or asset weight**, no new downloads, and negligible CPU. A "Loading Piano…" state covers the brief sample preload on first selection. (Note: the Salamander set is single-velocity, so velocity changes loudness rather than timbre — a deliberate trade for fast load, small footprint, and mobile/browser compatibility.)
+- **Lightweight** — pure Tone.js synthesis. Zero downloads, instant start, works offline and on slow connections.
+- **High Quality** (default) — sampled instruments (Salamander Grand piano, Casio electric piano) stream lazily in the background **while the lightweight version of the same sound is already playing**, then hot-swap in seamlessly. Playback is never blocked by a download.
 
-Sample loading is resilient by design via the `useInstrument` hook (`lib/audio/useInstrument.ts`), shared by the main page and the Sketchpad. Each sample-based preset is created with both `onload` and `onerror` callbacks plus a load timeout. If samples fail to download or stall — common on flaky mobile networks — the instrument **automatically falls back to the always-available FM Organ synth** and surfaces a brief, dismissible notice, so playback never gets stuck on an endless "Loading…" spinner.
+Instruments are described in two layers: a Tone-free catalog (`lib/audio/instrumentCatalog.ts`) holds ids/labels/categories for UI and settings code, and a registry (`lib/audio/synthPresets.ts`) maps each instrument to up to two *realizations* — a `lightweight` synth patch and an optional `high` sampler. Available sounds: **Lush Piano**, **Electric Piano**, **Soft Keys**, **Filtered Saw**, and **Organ**. Adding an instrument means one catalog entry plus one registry entry; playback code never changes. Playback humanization is a pure, dependency-free module (`lib/audio/humanization.ts`) that the scheduler applies per note.
+
+The instrument and quality choice persist across sessions via `lib/state/audioSettingsStore.ts` (localStorage), shared by the main page and the Sketchpad. Browsers with data-saver enabled default to Lightweight.
+
+Sample loading is resilient by design via the `useInstrument` hook (`lib/audio/useInstrument.ts`). Each sampler is created with `onload`/`onerror` callbacks plus a load timeout; if samples fail or stall — common on flaky mobile networks — playback **keeps using the lightweight twin of the same instrument** (a sampled piano degrades to a synth piano, not to an unrelated sound) and surfaces a brief, dismissible notice with a Retry option.
+
+The acoustic piano uses the [Salamander Grand Piano](https://github.com/sfzinstruments/SalamanderGrandPiano) sample set by Alexander Holm (CC-BY 3.0), served via the Tone.js audio CDN. (The hosted set is single-velocity, so velocity changes loudness rather than timbre — a deliberate trade for fast load, small footprint, and mobile/browser compatibility.)
 
 ## Usage
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,11 +20,12 @@ import { FeedbackChart } from "@/components/feedback/FeedbackChart";
 import { useFavoritesStore } from "@/lib/favorites/favoritesStore";
 import {
   SOUND_PRESETS,
-  createMelodySynthForPreset,
+  presetHasHighQuality,
+  type AudioQuality,
   type SoundPresetId,
-  type Synth,
-  type MelodySynth,
-} from "@/lib/audio/synthPresets";
+} from "@/lib/audio/instrumentCatalog";
+import type { Synth, MelodySynth } from "@/lib/audio/synthPresets";
+import { useAudioSettingsStore } from "@/lib/state/audioSettingsStore";
 import { useInstrument } from "@/lib/audio/useInstrument";
 import { midiToNoteName, normalizeToPitchClass, type PitchClass } from "@/lib/theory/midiUtils";
 import { keyPrefersFlats } from "@/lib/theory/spelling";
@@ -137,8 +138,14 @@ export default function HarmoniaPage() {
     setPlaybackStyle,
   } = usePlaybackSettingsStore();
 
+  const {
+    instrumentId: soundPreset,
+    quality: audioQuality,
+    setInstrument: setSoundPreset,
+    setQuality: setAudioQuality,
+  } = useAudioSettingsStore();
+
   const [playbackIndex, setPlaybackIndex] = useState<number | null>(null);
-  const [soundPreset, setSoundPreset] = useState<SoundPresetId>("piano");
   const [generationKey, setGenerationKey] = useState(0);
   const [selectedChordIndex, setSelectedChordIndex] = useState<number | null>(null);
   const [showVoicingControls, setShowVoicingControls] = useState(false);
@@ -158,31 +165,24 @@ export default function HarmoniaPage() {
   const playheadRef = useRef<HTMLDivElement>(null);
   const animFrameRef = useRef<number | null>(null);
 
-  /* ─── Synth lifecycle (loading + fallback handled by the hook) ─── */
+  /* ─── Synth lifecycle (loading, hot-swap + fallback handled by the hook) ─── */
 
   const {
     isLoading: isSynthLoading,
     loadError: synthLoadError,
+    activeQuality,
     dismissError: dismissSynthError,
-  } = useInstrument(soundPreset, { sustainMode, synthRef });
+    retry: retrySynthLoad,
+  } = useInstrument(soundPreset, { quality: audioQuality, sustainMode, synthRef });
 
-  /* ─── Melody synth lifecycle ─── */
+  /* ─── Melody synth lifecycle (same instrument & quality, melody voice) ─── */
 
-  useEffect(() => {
-    if (!melodyEnabled) {
-      if (melodySynthRef.current) {
-        melodySynthRef.current.dispose();
-        melodySynthRef.current = null;
-      }
-      return;
-    }
-    const synth = createMelodySynthForPreset(soundPreset);
-    melodySynthRef.current = synth;
-    return () => {
-      synth.dispose();
-      melodySynthRef.current = null;
-    };
-  }, [melodyEnabled, soundPreset]);
+  useInstrument(soundPreset, {
+    quality: audioQuality,
+    role: "melody",
+    enabled: melodyEnabled,
+    synthRef: melodySynthRef,
+  });
 
   /* ─── Transport BPM ─── */
 
@@ -898,9 +898,19 @@ export default function HarmoniaPage() {
 
         {/* ── Action Bar (Play · Chords · Melody · Save · Audio) ── */}
         <section>
-          {synthLoadError && (
+          {synthLoadError ? (
             <div className="flex items-center justify-center gap-2 mb-2 text-xs text-amber-600 dark:text-amber-400">
-              <span>{synthLoadError} couldn&apos;t load — using Organ instead.</span>
+              <span>
+                High-quality {synthLoadError} couldn&apos;t load — playing the lightweight
+                version.
+              </span>
+              <button
+                onClick={retrySynthLoad}
+                className="underline hover:no-underline"
+                aria-label="Retry loading samples"
+              >
+                Retry
+              </button>
               <button
                 onClick={dismissSynthError}
                 className="underline hover:no-underline"
@@ -909,25 +919,25 @@ export default function HarmoniaPage() {
                 Dismiss
               </button>
             </div>
-          )}
+          ) : isSynthLoading ? (
+            <div className="flex items-center justify-center gap-2 mb-2 text-xs text-muted">
+              <span className="w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin" />
+              <span>Loading high-quality {presetLabel} — playing lightweight sound meanwhile…</span>
+            </div>
+          ) : null}
           <div className="flex items-center justify-center gap-1.5 sm:gap-2 lg:gap-3">
 
             {/* Primary: Play / Stop */}
             <button
               onClick={handleTogglePlayback}
-              disabled={!currentProgression || isSynthLoading}
+              disabled={!currentProgression}
               className={`flex items-center justify-center gap-1.5 px-4 lg:px-6 py-2.5 rounded-full font-semibold text-sm transition-all duration-200 disabled:opacity-40 shrink-0 ${
                 isPlaying
                   ? "bg-surface text-foreground border border-border-subtle shadow-inner"
                   : "bg-accent text-white shadow-md hover:shadow-lg hover:-translate-y-0.5 active:translate-y-0"
               }`}
             >
-              {isSynthLoading ? (
-                <>
-                  <span className="w-3.5 h-3.5 border-2 border-current border-t-transparent rounded-full animate-spin" />
-                  Loading {presetLabel}…
-                </>
-              ) : isPlaying ? (
+              {isPlaying ? (
                 <>
                   <Square className="w-4 h-4" />
                   Stop
@@ -1011,7 +1021,19 @@ export default function HarmoniaPage() {
                     </span>
                     <div className="px-3 pb-1.5 pt-0.5">
                       <div className="flex items-center justify-between gap-2">
-                        <span className="text-sm font-medium text-foreground">Instrument</span>
+                        <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+                          Instrument
+                          {isSynthLoading ? (
+                            <span
+                              className="w-3 h-3 border-2 border-muted border-t-transparent rounded-full animate-spin"
+                              title="Loading high-quality samples"
+                            />
+                          ) : activeQuality === "high" ? (
+                            <span className="px-1 py-px rounded text-[9px] font-bold uppercase tracking-wide bg-accent/10 text-accent">
+                              HQ
+                            </span>
+                          ) : null}
+                        </span>
                         <div className="relative">
                           <select
                             value={soundPreset}
@@ -1019,13 +1041,54 @@ export default function HarmoniaPage() {
                             className="appearance-none bg-background/60 border border-border-subtle rounded-lg pl-3 pr-7 py-1.5 text-sm font-medium text-foreground outline-none cursor-pointer hover:border-accent/40 transition-colors"
                             title="Instrument preset"
                           >
-                            {SOUND_PRESETS.map((preset) => (
-                              <option key={preset.id} value={preset.id}>{preset.label}</option>
-                            ))}
+                            <optgroup label="Keys">
+                              {SOUND_PRESETS.filter((p) => p.category === "keys").map((preset) => (
+                                <option key={preset.id} value={preset.id}>{preset.label}</option>
+                              ))}
+                            </optgroup>
+                            <optgroup label="Synths">
+                              {SOUND_PRESETS.filter((p) => p.category === "synth").map((preset) => (
+                                <option key={preset.id} value={preset.id}>{preset.label}</option>
+                              ))}
+                            </optgroup>
                           </select>
                           <ChevronDown className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted" />
                         </div>
                       </div>
+                    </div>
+
+                    {/* Audio quality mode */}
+                    <div className="px-3 pb-1.5 flex flex-col gap-1">
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="text-sm font-medium text-foreground">Audio quality</span>
+                        <div className="flex items-center rounded-lg bg-background/60 border border-border-subtle p-0.5">
+                          {(
+                            [
+                              { value: "lightweight", label: "Light" },
+                              { value: "high", label: "High" },
+                            ] as const
+                          ).map((q) => (
+                            <button
+                              key={q.value}
+                              onClick={() => setAudioQuality(q.value as AudioQuality)}
+                              className={`px-2.5 py-1 rounded-md text-[11px] font-medium transition-colors ${
+                                audioQuality === q.value
+                                  ? "bg-accent text-white shadow-sm"
+                                  : "text-muted hover:text-foreground"
+                              }`}
+                            >
+                              {q.label}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                      <p className="text-[10px] leading-snug text-muted">
+                        {audioQuality === "high"
+                          ? presetHasHighQuality(soundPreset)
+                            ? "Real instrument samples (a few MB) download in the background — playback starts right away on the lightweight sound."
+                            : "This instrument is synth-based; it sounds the same in both modes."
+                          : "Instant synth sound. No downloads — ideal for slow connections."}
+                      </p>
                     </div>
 
                     <div className="my-1 h-px bg-border-subtle" />

--- a/components/sketchpad/HarmonicPreviewPanel.tsx
+++ b/components/sketchpad/HarmonicPreviewPanel.tsx
@@ -23,7 +23,7 @@ import type {
   PlaybackMode,
 } from "@/lib/sketchpad/types";
 import type { Mode } from "@/lib/theory/harmonyEngine";
-import { SOUND_PRESETS } from "@/lib/audio/synthPresets";
+import { SOUND_PRESETS, type SoundPresetId } from "@/lib/audio/instrumentCatalog";
 import clsx from "clsx";
 
 const MODES: { value: Mode; label: string }[] = [
@@ -80,8 +80,8 @@ export function HarmonicPreviewPanel({
   onPlayTransition: () => void;
   onStop: () => void;
   onPlayNote: (noteWithOctave: string) => void;
-  soundPreset: string;
-  onSoundPresetChange: (preset: any) => void;
+  soundPreset: SoundPresetId;
+  onSoundPresetChange: (preset: SoundPresetId) => void;
   isSynthLoading: boolean;
   synthLoadError: string | null;
   onDismissSynthError: () => void;
@@ -118,20 +118,28 @@ export function HarmonicPreviewPanel({
           <span className="text-xs font-medium text-muted uppercase tracking-wider">
             Preview
           </span>
-          <select
-            value={soundPreset}
-            onChange={(e) => onSoundPresetChange(e.target.value)}
-            className="bg-surface-muted border border-border-subtle rounded px-2 py-0.5 text-xs outline-none appearance-none cursor-pointer"
-          >
-            {SOUND_PRESETS.map((p) => (
-              <option key={p.id} value={p.id}>{p.label}</option>
-            ))}
-          </select>
+          <span className="flex items-center gap-1.5">
+            {isSynthLoading && (
+              <span
+                className="w-3 h-3 border-2 border-muted border-t-transparent rounded-full animate-spin"
+                title="Loading high-quality samples"
+              />
+            )}
+            <select
+              value={soundPreset}
+              onChange={(e) => onSoundPresetChange(e.target.value as SoundPresetId)}
+              className="bg-surface-muted border border-border-subtle rounded px-2 py-0.5 text-xs outline-none appearance-none cursor-pointer"
+            >
+              {SOUND_PRESETS.map((p) => (
+                <option key={p.id} value={p.id}>{p.label}</option>
+              ))}
+            </select>
+          </span>
         </div>
 
         {synthLoadError && (
           <div className="flex items-center justify-between gap-2 mb-2 text-[11px] text-amber-600 dark:text-amber-400">
-            <span>{synthLoadError} couldn&apos;t load — using Organ.</span>
+            <span>High-quality {synthLoadError} couldn&apos;t load — using the lightweight sound.</span>
             <button
               onClick={onDismissSynthError}
               className="underline hover:no-underline shrink-0"
@@ -156,19 +164,15 @@ export function HarmonicPreviewPanel({
             <>
               <button
                 onClick={() => onPlaySection(false)}
-                disabled={events.length === 0 || isSynthLoading}
+                disabled={events.length === 0}
                 className="flex items-center gap-1 px-2.5 py-1 rounded-md bg-accent text-white text-xs font-medium hover:opacity-90 disabled:opacity-40"
               >
-                {isSynthLoading ? (
-                  <span className="w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin" />
-                ) : (
-                  <Play className="w-3 h-3" />
-                )}
+                <Play className="w-3 h-3" />
                 Section
               </button>
               <button
                 onClick={() => onPlaySection(true)}
-                disabled={events.length === 0 || isSynthLoading}
+                disabled={events.length === 0}
                 className="flex items-center gap-1 px-2.5 py-1 rounded-md bg-surface-muted border border-border-subtle text-xs font-medium hover:bg-accent/10 disabled:opacity-40"
                 title="Loop section"
               >
@@ -176,7 +180,7 @@ export function HarmonicPreviewPanel({
               </button>
               <button
                 onClick={() => onPlayFullSong(0)}
-                disabled={project.sections.length === 0 || isSynthLoading}
+                disabled={project.sections.length === 0}
                 className="flex items-center gap-1 px-2.5 py-1 rounded-md bg-surface-muted border border-border-subtle text-xs font-medium hover:bg-accent/10 disabled:opacity-40"
                 title="Play full song"
               >
@@ -186,7 +190,7 @@ export function HarmonicPreviewPanel({
               {hasNextSection && (
                 <button
                   onClick={onPlayTransition}
-                  disabled={events.length === 0 || isSynthLoading}
+                  disabled={events.length === 0}
                   className="flex items-center gap-1 px-2.5 py-1 rounded-md bg-surface-muted border border-border-subtle text-xs font-medium hover:bg-accent/10 disabled:opacity-40"
                   title="Preview transition to next section"
                 >

--- a/components/sketchpad/Workspace.tsx
+++ b/components/sketchpad/Workspace.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useMemo, useCallback, useRef, useState, useEffect } from "react";
+import { useMemo, useCallback, useRef, useEffect } from "react";
 import * as Tone from "tone";
 import type { HarmonicSketchProject, HarmonicSection, HarmonicEvent, PlaybackMode } from "@/lib/sketchpad/types";
 import { useSketchpadStore } from "@/lib/sketchpad/store";
 import { SongStructurePanel } from "./SongStructurePanel";
 import { SectionEditorPanel } from "./SectionEditorPanel";
 import { HarmonicPreviewPanel } from "./HarmonicPreviewPanel";
-import { type SoundPresetId, type Synth } from "@/lib/audio/synthPresets";
+import { type Synth } from "@/lib/audio/synthPresets";
+import { useAudioSettingsStore } from "@/lib/state/audioSettingsStore";
 import { useInstrument } from "@/lib/audio/useInstrument";
 
 function beatsToDuration(beats: number): string {
@@ -32,13 +33,17 @@ export function SketchpadWorkspace({ project }: { project: HarmonicSketchProject
     setPlaybackPosition,
   } = useSketchpadStore();
 
-  const [soundPreset, setSoundPreset] = useState<SoundPresetId>("piano");
+  const {
+    instrumentId: soundPreset,
+    quality: audioQuality,
+    setInstrument: setSoundPreset,
+  } = useAudioSettingsStore();
   const synthRef = useRef<Synth | null>(null);
   const {
     isLoading: isSynthLoading,
     loadError: synthLoadError,
     dismissError: dismissSynthError,
-  } = useInstrument(soundPreset, { synthRef });
+  } = useInstrument(soundPreset, { quality: audioQuality, synthRef });
   const scheduleIdsRef = useRef<number[]>([]);
 
   const activeSection = useMemo(

--- a/lib/audio/__tests__/instrumentCatalog.test.ts
+++ b/lib/audio/__tests__/instrumentCatalog.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_INSTRUMENT,
+  INSTRUMENT_CATALOG,
+  SOUND_PRESETS,
+  getCatalogEntry,
+  presetHasHighQuality,
+  resolvePresetId,
+} from "../instrumentCatalog";
+
+describe("instrumentCatalog", () => {
+  it("has unique ids", () => {
+    const ids = INSTRUMENT_CATALOG.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("includes the default instrument", () => {
+    expect(INSTRUMENT_CATALOG.some((e) => e.id === DEFAULT_INSTRUMENT)).toBe(true);
+  });
+
+  it("exposes the full target palette", () => {
+    const ids = INSTRUMENT_CATALOG.map((e) => e.id);
+    expect(ids).toContain("piano");
+    expect(ids).toContain("electric-piano");
+    expect(ids).toContain("soft-keys");
+    expect(ids).toContain("filtered-saw");
+    expect(ids).toContain("organ");
+  });
+
+  it("marks only sampled instruments as high-quality capable", () => {
+    expect(presetHasHighQuality("piano")).toBe(true);
+    expect(presetHasHighQuality("electric-piano")).toBe(true);
+    expect(presetHasHighQuality("soft-keys")).toBe(false);
+    expect(presetHasHighQuality("filtered-saw")).toBe(false);
+    expect(presetHasHighQuality("organ")).toBe(false);
+  });
+
+  it("resolves unknown or stale ids to the default instrument", () => {
+    expect(resolvePresetId("piano")).toBe("piano");
+    expect(resolvePresetId("no-such-instrument")).toBe(DEFAULT_INSTRUMENT);
+    expect(resolvePresetId(undefined)).toBe(DEFAULT_INSTRUMENT);
+    expect(resolvePresetId(42)).toBe(DEFAULT_INSTRUMENT);
+  });
+
+  it("getCatalogEntry never returns undefined", () => {
+    for (const entry of INSTRUMENT_CATALOG) {
+      expect(getCatalogEntry(entry.id)).toBe(entry);
+    }
+  });
+
+  it("keeps the back-compat SOUND_PRESETS alias in sync", () => {
+    expect(SOUND_PRESETS).toBe(INSTRUMENT_CATALOG);
+  });
+});

--- a/lib/audio/instrumentCatalog.ts
+++ b/lib/audio/instrumentCatalog.ts
@@ -1,0 +1,62 @@
+/**
+ * Instrument Catalog (metadata only — no Tone.js dependency)
+ *
+ * The user-facing list of instruments and audio quality modes. UI components
+ * and the settings store import from here so they never pull Tone.js into
+ * their module graph; the actual synth/sampler construction lives in
+ * `synthPresets.ts`, which consumes this catalog.
+ */
+
+/** Stable instrument identifiers. Persisted in localStorage — don't rename. */
+export type SoundPresetId =
+  | "piano"
+  | "electric-piano"
+  | "soft-keys"
+  | "filtered-saw"
+  | "organ";
+
+/**
+ * Playback quality mode.
+ * - "lightweight": pure synthesis, zero downloads, instant start.
+ * - "high": sampled instruments stream in the background and hot-swap in when
+ *   ready; playback starts immediately on the lightweight realization.
+ */
+export type AudioQuality = "lightweight" | "high";
+
+export interface InstrumentCatalogEntry {
+  id: SoundPresetId;
+  label: string;
+  category: "keys" | "synth";
+  /** True when a sampled (high-quality) realization exists for this sound. */
+  hasHighQuality: boolean;
+}
+
+/** Ordered list of selectable instruments (drives UI menus). */
+export const INSTRUMENT_CATALOG: ReadonlyArray<InstrumentCatalogEntry> = [
+  { id: "piano", label: "Lush Piano", category: "keys", hasHighQuality: true },
+  { id: "electric-piano", label: "Electric Piano", category: "keys", hasHighQuality: true },
+  { id: "soft-keys", label: "Soft Keys", category: "keys", hasHighQuality: false },
+  { id: "filtered-saw", label: "Filtered Saw", category: "synth", hasHighQuality: false },
+  { id: "organ", label: "Organ", category: "synth", hasHighQuality: false },
+];
+
+/** Back-compat alias used by existing menus. */
+export const SOUND_PRESETS = INSTRUMENT_CATALOG;
+
+export const DEFAULT_INSTRUMENT: SoundPresetId = "piano";
+
+const CATALOG_BY_ID = new Map(INSTRUMENT_CATALOG.map((e) => [e.id, e]));
+
+/** Map any (possibly stale/persisted) id to a valid catalog entry id. */
+export function resolvePresetId(id: unknown): SoundPresetId {
+  return CATALOG_BY_ID.has(id as SoundPresetId) ? (id as SoundPresetId) : DEFAULT_INSTRUMENT;
+}
+
+export function getCatalogEntry(id: SoundPresetId): InstrumentCatalogEntry {
+  return CATALOG_BY_ID.get(resolvePresetId(id))!;
+}
+
+/** True when the preset has a sampled realization (relevant in "high" mode). */
+export function presetHasHighQuality(id: SoundPresetId): boolean {
+  return getCatalogEntry(id).hasHighQuality;
+}

--- a/lib/audio/synthPresets.ts
+++ b/lib/audio/synthPresets.ts
@@ -1,18 +1,37 @@
 /**
  * Shared Synth Presets & Effects Chain
  *
- * Centralised audio setup used by the main progression page (and available to
- * the Sketchpad workspace). Instruments are described by a small registry so
- * new instruments (Strings, Pad, …) can be added as a single entry without
- * touching call sites.
+ * Centralised audio setup used by the main progression page and the Sketchpad
+ * workspace. Each instrument in the registry describes up to two
+ * *realizations* of the same musical identity:
+ *
+ * - `lightweight` — pure Tone.js synthesis: zero downloads, instant start,
+ *   works offline. Every instrument has one; it doubles as the fallback when
+ *   sample loading fails, so degradation keeps the timbre family.
+ * - `high` — a `Tone.Sampler` realization streaming real instrument samples.
+ *   Loaded lazily; `useInstrument` plays the lightweight twin until the
+ *   sampler's `onload` fires, then hot-swaps.
+ *
+ * Instrument metadata (ids, labels, categories) lives in
+ * `instrumentCatalog.ts`, which is Tone-free so UI code can import it without
+ * pulling Tone.js into its module graph.
  */
 
 import * as Tone from "tone";
 import type { SustainMode } from "./humanization";
+import {
+  INSTRUMENT_CATALOG,
+  resolvePresetId,
+  type AudioQuality,
+  type InstrumentCatalogEntry,
+  type SoundPresetId,
+} from "./instrumentCatalog";
+
+export type { AudioQuality, SoundPresetId } from "./instrumentCatalog";
+export { SOUND_PRESETS, presetHasHighQuality } from "./instrumentCatalog";
 
 /* ─── Types ─── */
 
-export type SoundPresetId = "piano" | "electric-piano" | "organ";
 export type Synth = Tone.PolySynth | Tone.Sampler;
 export type MelodySynth = Tone.Synth | Tone.FMSynth | Tone.Sampler;
 
@@ -33,19 +52,24 @@ export interface CreateMelodySynthOptions {
   onError?: (err: Error) => void;
 }
 
-/**
- * A self-contained description of a playable instrument. Adding a new
- * instrument means adding one entry to {@link INSTRUMENTS} — call sites stay
- * unchanged.
- */
-export interface InstrumentDefinition {
-  id: SoundPresetId;
-  label: string;
-  category: "keys" | "synth";
-  /** Whether the instrument downloads samples (show a loading state). */
+/** One playable rendering of an instrument at a given quality tier. */
+export interface InstrumentRealization {
+  /** Whether this realization downloads samples (show a loading state). */
   needsLoading: boolean;
   create: (opts: CreateSynthOptions) => Synth;
   createMelody: (opts: CreateMelodySynthOptions) => MelodySynth;
+}
+
+/**
+ * A self-contained description of a playable instrument. Adding a new
+ * instrument means one catalog entry plus one registry entry — call sites
+ * stay unchanged.
+ */
+export interface InstrumentDefinition extends InstrumentCatalogEntry {
+  realizations: {
+    lightweight: InstrumentRealization;
+    high?: InstrumentRealization;
+  };
 }
 
 /* ─── Release tuning ─── */
@@ -57,6 +81,9 @@ function pianoRelease(mode: SustainMode | undefined): number {
 function epRelease(mode: SustainMode | undefined): number {
   return mode === "off" ? 0.2 : 0.8;
 }
+function padRelease(mode: SustainMode | undefined): number {
+  return mode === "off" ? 0.3 : 1.4;
+}
 
 /* ─── Effects Chain (lazy singletons) ─── */
 
@@ -65,6 +92,8 @@ let masterCompressor: Tone.Compressor | null = null;
 let masterLimiter: Tone.Limiter | null = null;
 let pianoReverbNode: Tone.Reverb | null = null;
 let epChorusNode: Tone.Chorus | null = null;
+let padChorusNode: Tone.Chorus | null = null;
+let sawFilterNode: Tone.Filter | null = null;
 
 export function getEffectsChain(): {
   reverb: Tone.Reverb;
@@ -106,6 +135,30 @@ function getEPChorus(): Tone.Chorus {
   return epChorusNode;
 }
 
+/** Slow, wide chorus shared by the pad-style voices (Soft Keys, Filtered Saw). */
+function getPadChorus(): Tone.Chorus {
+  if (!padChorusNode) {
+    const { compressor } = getEffectsChain();
+    padChorusNode = new Tone.Chorus({ frequency: 0.6, delayTime: 4.5, depth: 0.5, wet: 0.3 })
+      .connect(compressor)
+      .start();
+  }
+  return padChorusNode;
+}
+
+/** Mellow lowpass that takes the edge off the Filtered Saw voice. */
+function getSawFilter(): Tone.Filter {
+  if (!sawFilterNode) {
+    sawFilterNode = new Tone.Filter({
+      frequency: 1100,
+      type: "lowpass",
+      rolloff: -24,
+      Q: 0.8,
+    }).connect(getPadChorus());
+  }
+  return sawFilterNode;
+}
+
 /* ─── Sample maps (shared between chord & melody samplers) ─── */
 
 const SALAMANDER_URLS = {
@@ -128,140 +181,285 @@ const CASIO_URLS = {
   A2: "A2.mp3",
 } as const;
 
+/* ─── Lightweight synth voices ─── */
+
+/** Percussive, mellow synth-piano: the lightweight twin of the sampled piano. */
+function createSynthPiano(sustainMode: SustainMode | undefined): Tone.PolySynth {
+  const { compressor } = getEffectsChain();
+  const synth = new Tone.PolySynth(Tone.Synth, {
+    volume: -10,
+    oscillator: { type: "triangle8" },
+    envelope: { attack: 0.004, decay: 1.6, sustain: 0.18, release: pianoRelease(sustainMode) },
+  });
+  synth.connect(compressor);
+  synth.connect(getPianoReverb());
+  return synth;
+}
+
+function createSynthPianoMelody(): Tone.Synth {
+  const { compressor } = getEffectsChain();
+  const synth = new Tone.Synth({
+    volume: -8,
+    oscillator: { type: "triangle8" },
+    envelope: { attack: 0.004, decay: 1.6, sustain: 0.18, release: 1 },
+  });
+  synth.connect(compressor);
+  synth.connect(getPianoReverb());
+  return synth;
+}
+
+/** Classic FM electric piano: the lightweight twin of the sampled EP. */
+function epFmOptions(sustainMode: SustainMode | undefined) {
+  return {
+    harmonicity: 2,
+    modulationIndex: 1.4,
+    oscillator: { type: "sine" as const },
+    modulation: { type: "sine" as const },
+    envelope: {
+      attack: 0.004,
+      decay: 1.1,
+      sustain: 0.25,
+      release: epRelease(sustainMode),
+    },
+    modulationEnvelope: { attack: 0.002, decay: 0.5, sustain: 0.08, release: 0.3 },
+  };
+}
+
 /* ─── Instrument Registry ─── */
 
+const catalogEntry = (id: SoundPresetId): InstrumentCatalogEntry =>
+  INSTRUMENT_CATALOG.find((e) => e.id === id)!;
+
 export const INSTRUMENTS: Record<SoundPresetId, InstrumentDefinition> = {
-  /* ── Piano: Salamander Grand Piano samples ── */
+  /* ── Lush Piano: Salamander Grand samples (HQ) / mellow synth piano (LW) ── */
   piano: {
-    id: "piano",
-    label: "Piano",
-    category: "keys",
-    needsLoading: true,
-    create: ({ sustainMode, onLoaded, onError }) => {
-      const { compressor } = getEffectsChain();
-      const sampler = new Tone.Sampler({
-        urls: SALAMANDER_URLS,
-        baseUrl: "https://tonejs.github.io/audio/salamander/",
-        release: pianoRelease(sustainMode),
-        volume: -6,
-        onload: () => onLoaded?.(),
-        onerror: (err) => onError?.(err),
-      });
-      sampler.connect(compressor);
-      sampler.connect(getPianoReverb());
-      return sampler;
-    },
-    createMelody: ({ onLoaded, onError }) => {
-      const { compressor } = getEffectsChain();
-      const sampler = new Tone.Sampler({
-        urls: SALAMANDER_URLS,
-        baseUrl: "https://tonejs.github.io/audio/salamander/",
-        release: 1,
-        volume: -4,
-        onload: () => onLoaded?.(),
-        onerror: (err) => onError?.(err),
-      });
-      sampler.connect(compressor);
-      sampler.connect(getPianoReverb());
-      return sampler;
+    ...catalogEntry("piano"),
+    realizations: {
+      lightweight: {
+        needsLoading: false,
+        create: ({ sustainMode, onLoaded }) => {
+          onLoaded?.();
+          return createSynthPiano(sustainMode);
+        },
+        createMelody: ({ onLoaded }) => {
+          onLoaded?.();
+          return createSynthPianoMelody();
+        },
+      },
+      high: {
+        needsLoading: true,
+        create: ({ sustainMode, onLoaded, onError }) => {
+          const { compressor } = getEffectsChain();
+          const sampler = new Tone.Sampler({
+            urls: SALAMANDER_URLS,
+            baseUrl: "https://tonejs.github.io/audio/salamander/",
+            release: pianoRelease(sustainMode),
+            volume: -6,
+            onload: () => onLoaded?.(),
+            onerror: (err) => onError?.(err),
+          });
+          sampler.connect(compressor);
+          sampler.connect(getPianoReverb());
+          return sampler;
+        },
+        createMelody: ({ onLoaded, onError }) => {
+          const { compressor } = getEffectsChain();
+          const sampler = new Tone.Sampler({
+            urls: SALAMANDER_URLS,
+            baseUrl: "https://tonejs.github.io/audio/salamander/",
+            release: 1,
+            volume: -4,
+            onload: () => onLoaded?.(),
+            onerror: (err) => onError?.(err),
+          });
+          sampler.connect(compressor);
+          sampler.connect(getPianoReverb());
+          return sampler;
+        },
+      },
     },
   },
 
-  /* ── Electric Piano: Casio samples ── */
+  /* ── Electric Piano: Casio samples (HQ) / FM tine piano (LW) ── */
   "electric-piano": {
-    id: "electric-piano",
-    label: "Electric Piano",
-    category: "keys",
-    needsLoading: true,
-    create: ({ sustainMode, onLoaded, onError }) => {
-      const sampler = new Tone.Sampler({
-        urls: CASIO_URLS,
-        baseUrl: "https://tonejs.github.io/audio/casio/",
-        release: epRelease(sustainMode),
-        volume: -8,
-        onload: () => onLoaded?.(),
-        onerror: (err) => onError?.(err),
-      });
-      sampler.connect(getEPChorus());
-      return sampler;
+    ...catalogEntry("electric-piano"),
+    realizations: {
+      lightweight: {
+        needsLoading: false,
+        create: ({ sustainMode, onLoaded }) => {
+          onLoaded?.();
+          return new Tone.PolySynth(Tone.FMSynth, {
+            volume: -12,
+            ...epFmOptions(sustainMode),
+          }).connect(getEPChorus());
+        },
+        createMelody: ({ onLoaded }) => {
+          onLoaded?.();
+          return new Tone.FMSynth({ volume: -10, ...epFmOptions(undefined) }).connect(
+            getEPChorus(),
+          );
+        },
+      },
+      high: {
+        needsLoading: true,
+        create: ({ sustainMode, onLoaded, onError }) => {
+          const sampler = new Tone.Sampler({
+            urls: CASIO_URLS,
+            baseUrl: "https://tonejs.github.io/audio/casio/",
+            release: epRelease(sustainMode),
+            volume: -8,
+            onload: () => onLoaded?.(),
+            onerror: (err) => onError?.(err),
+          });
+          sampler.connect(getEPChorus());
+          return sampler;
+        },
+        createMelody: ({ onLoaded, onError }) => {
+          const sampler = new Tone.Sampler({
+            urls: CASIO_URLS,
+            baseUrl: "https://tonejs.github.io/audio/casio/",
+            release: 0.8,
+            volume: -6,
+            onload: () => onLoaded?.(),
+            onerror: (err) => onError?.(err),
+          });
+          sampler.connect(getEPChorus());
+          return sampler;
+        },
+      },
     },
-    createMelody: ({ onLoaded, onError }) => {
-      const sampler = new Tone.Sampler({
-        urls: CASIO_URLS,
-        baseUrl: "https://tonejs.github.io/audio/casio/",
-        release: 0.8,
-        volume: -6,
-        onload: () => onLoaded?.(),
-        onerror: (err) => onError?.(err),
-      });
-      sampler.connect(getEPChorus());
-      return sampler;
+  },
+
+  /* ── Soft Keys: gentle detuned triangles through slow chorus ── */
+  "soft-keys": {
+    ...catalogEntry("soft-keys"),
+    realizations: {
+      lightweight: {
+        needsLoading: false,
+        create: ({ sustainMode, onLoaded }) => {
+          onLoaded?.();
+          return new Tone.PolySynth(Tone.Synth, {
+            volume: -11,
+            oscillator: { type: "fattriangle", count: 3, spread: 16 },
+            envelope: {
+              attack: 0.025,
+              decay: 0.4,
+              sustain: 0.65,
+              release: padRelease(sustainMode),
+            },
+          }).connect(getPadChorus());
+        },
+        createMelody: ({ onLoaded }) => {
+          onLoaded?.();
+          return new Tone.Synth({
+            volume: -9,
+            oscillator: { type: "fattriangle", count: 3, spread: 16 },
+            envelope: { attack: 0.02, decay: 0.4, sustain: 0.65, release: 1.2 },
+          }).connect(getPadChorus());
+        },
+      },
+    },
+  },
+
+  /* ── Filtered Saw: mellow polysynth pad, fat saws into a dark lowpass ── */
+  "filtered-saw": {
+    ...catalogEntry("filtered-saw"),
+    realizations: {
+      lightweight: {
+        needsLoading: false,
+        create: ({ sustainMode, onLoaded }) => {
+          onLoaded?.();
+          return new Tone.PolySynth(Tone.Synth, {
+            volume: -14,
+            oscillator: { type: "fatsawtooth", count: 3, spread: 22 },
+            envelope: {
+              attack: 0.05,
+              decay: 0.35,
+              sustain: 0.75,
+              release: padRelease(sustainMode),
+            },
+          }).connect(getSawFilter());
+        },
+        createMelody: ({ onLoaded }) => {
+          onLoaded?.();
+          return new Tone.Synth({
+            volume: -12,
+            oscillator: { type: "fatsawtooth", count: 3, spread: 22 },
+            envelope: { attack: 0.04, decay: 0.35, sustain: 0.75, release: 1.3 },
+          }).connect(getSawFilter());
+        },
+      },
     },
   },
 
   /* ── Organ: FM synthesis with drawbar-style harmonics ── */
   organ: {
-    id: "organ",
-    label: "Organ",
-    category: "synth",
-    needsLoading: false,
-    create: ({ onLoaded }) => {
-      const { compressor } = getEffectsChain();
-      onLoaded?.();
-      return new Tone.PolySynth(Tone.FMSynth, {
-        volume: -14,
-        harmonicity: 1,
-        modulationIndex: 0.5,
-        oscillator: { type: "sine" },
-        modulation: { type: "sine" },
-        envelope: { attack: 0.04, decay: 0.1, sustain: 0.9, release: 0.3 },
-        modulationEnvelope: { attack: 0.02, decay: 0.1, sustain: 0.8, release: 0.3 },
-      }).connect(compressor);
-    },
-    createMelody: ({ onLoaded }) => {
-      const { compressor } = getEffectsChain();
-      onLoaded?.();
-      return new Tone.FMSynth({
-        volume: -12,
-        harmonicity: 1,
-        modulationIndex: 0.5,
-        oscillator: { type: "sine" },
-        modulation: { type: "sine" },
-        envelope: { attack: 0.04, decay: 0.1, sustain: 0.9, release: 0.3 },
-        modulationEnvelope: { attack: 0.02, decay: 0.1, sustain: 0.8, release: 0.3 },
-      }).connect(compressor);
+    ...catalogEntry("organ"),
+    realizations: {
+      lightweight: {
+        needsLoading: false,
+        create: ({ onLoaded }) => {
+          const { compressor } = getEffectsChain();
+          onLoaded?.();
+          return new Tone.PolySynth(Tone.FMSynth, {
+            volume: -14,
+            harmonicity: 1,
+            modulationIndex: 0.5,
+            oscillator: { type: "sine" },
+            modulation: { type: "sine" },
+            envelope: { attack: 0.04, decay: 0.1, sustain: 0.9, release: 0.3 },
+            modulationEnvelope: { attack: 0.02, decay: 0.1, sustain: 0.8, release: 0.3 },
+          }).connect(compressor);
+        },
+        createMelody: ({ onLoaded }) => {
+          const { compressor } = getEffectsChain();
+          onLoaded?.();
+          return new Tone.FMSynth({
+            volume: -12,
+            harmonicity: 1,
+            modulationIndex: 0.5,
+            oscillator: { type: "sine" },
+            modulation: { type: "sine" },
+            envelope: { attack: 0.04, decay: 0.1, sustain: 0.9, release: 0.3 },
+            modulationEnvelope: { attack: 0.02, decay: 0.1, sustain: 0.8, release: 0.3 },
+          }).connect(compressor);
+        },
+      },
     },
   },
 };
 
-/** Ordered list of selectable instruments (for UI menus). */
-export const SOUND_PRESETS: ReadonlyArray<{ id: SoundPresetId; label: string }> =
-  Object.values(INSTRUMENTS).map(({ id, label }) => ({ id, label }));
-
 /* ─── Public factory API (thin lookups over the registry) ─── */
 
-function resolveInstrument(preset: SoundPresetId): InstrumentDefinition {
-  return INSTRUMENTS[preset] ?? INSTRUMENTS.piano;
+function resolveRealization(
+  preset: SoundPresetId,
+  quality: AudioQuality,
+): InstrumentRealization {
+  const def = INSTRUMENTS[resolvePresetId(preset)];
+  if (quality === "high" && def.realizations.high) return def.realizations.high;
+  return def.realizations.lightweight;
 }
 
 export function createSynthForPreset(
   preset: SoundPresetId,
+  quality: AudioQuality,
   opts: CreateSynthOptions = {},
 ): Synth {
-  return resolveInstrument(preset).create(opts);
+  return resolveRealization(preset, quality).create(opts);
 }
 
 export function createMelodySynthForPreset(
   preset: SoundPresetId,
+  quality: AudioQuality,
   opts: CreateMelodySynthOptions = {},
 ): MelodySynth {
-  return resolveInstrument(preset).createMelody(opts);
+  return resolveRealization(preset, quality).createMelody(opts);
 }
 
 /**
- * Returns true when the given preset needs async loading (sample-based).
- * Useful for showing a loading spinner while samples download.
+ * Returns true when the given preset at the given quality needs async loading
+ * (sample-based). Useful for showing a loading state while samples download.
  */
-export function presetNeedsLoading(preset: SoundPresetId): boolean {
-  return resolveInstrument(preset).needsLoading;
+export function presetNeedsLoading(preset: SoundPresetId, quality: AudioQuality): boolean {
+  return resolveRealization(preset, quality).needsLoading;
 }

--- a/lib/audio/useInstrument.ts
+++ b/lib/audio/useInstrument.ts
@@ -1,60 +1,126 @@
 /**
- * useInstrument — chord-instrument lifecycle with loading state and fallback.
+ * useInstrument — instrument lifecycle with quality modes, hot-swap, and
+ * timbre-preserving fallback.
  *
- * Centralises the synth lifecycle that the main progression page and the
- * Sketchpad workspace previously duplicated. Beyond creating/disposing the
- * instrument, it guarantees the UI can never get stuck on a "Loading…" state:
- * if sample loading errors or takes too long, it disposes the failed
- * instrument, falls back to the always-available Organ synth, and exposes a
- * `loadError` label so callers can surface a brief notice.
+ * Centralises the synth lifecycle shared by the main progression page and the
+ * Sketchpad workspace. The contract:
+ *
+ * - A playable instrument is available **synchronously**: the lightweight
+ *   (pure-synth) realization is created immediately, so playback never waits
+ *   on a download and the Play button never needs disabling.
+ * - In "high" quality mode, the sampled realization loads in the background
+ *   and is **hot-swapped** into `synthRef` when ready — ringing lightweight
+ *   notes are released and the old instrument is disposed after its tail.
+ * - If sample loading errors or times out, the lightweight twin of the *same*
+ *   instrument keeps playing (degradation preserves the timbre family), and
+ *   `loadError` carries the instrument label so callers can surface a notice
+ *   with a `retry()` affordance.
  */
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { SustainMode } from "./humanization";
+import { presetHasHighQuality, type AudioQuality } from "./instrumentCatalog";
 import {
   INSTRUMENTS,
+  createMelodySynthForPreset,
   createSynthForPreset,
-  presetNeedsLoading,
+  type MelodySynth,
   type SoundPresetId,
   type Synth,
 } from "./synthPresets";
 
-/** Instrument used when a sample-based preset fails to load. */
-const FALLBACK_PRESET: SoundPresetId = "organ";
-
-/** How long to wait for samples before treating the load as failed (ms). */
+/** How long to wait for samples before falling back to lightweight (ms). */
 const LOAD_TIMEOUT_MS = 10_000;
 
-export interface UseInstrumentOptions {
+/** How long a replaced instrument keeps ringing before disposal (ms). */
+const SWAP_DISPOSE_DELAY_MS = 3_000;
+
+type Playable = Synth | MelodySynth;
+
+/** Release any held/ringing notes on either a poly or mono instrument. */
+function silence(inst: Playable): void {
+  if ("releaseAll" in inst && typeof inst.releaseAll === "function") {
+    inst.releaseAll();
+  } else if ("triggerRelease" in inst && typeof inst.triggerRelease === "function") {
+    (inst as MelodySynth & { triggerRelease: () => void }).triggerRelease();
+  }
+}
+
+function safeDispose(inst: Playable | null): void {
+  if (!inst) return;
+  try {
+    inst.dispose();
+  } catch {
+    // Disposing an already-disposed node throws in some Tone versions; ignore.
+  }
+}
+
+export interface UseInstrumentOptions<T extends Playable> {
+  /** Quality mode; "high" lazily loads samples where the instrument has them. */
+  quality: AudioQuality;
   sustainMode?: SustainMode;
+  /** Build the melody (mono-oriented) realization instead of the chord one. */
+  role?: "chord" | "melody";
+  /** When false, no instrument is created (e.g. melody lane disabled). */
+  enabled?: boolean;
   /**
    * Caller-owned ref that receives the live instrument. Passing the ref in
    * (rather than returning a new one) keeps it a stable `useRef` at the call
    * site so React's exhaustive-deps lint stays happy.
    */
-  synthRef: React.MutableRefObject<Synth | null>;
+  synthRef: React.MutableRefObject<T | null>;
 }
 
 export interface UseInstrumentResult {
-  /** True while sample-based instruments download. */
+  /** True while a high-quality (sampled) realization downloads. */
   isLoading: boolean;
-  /** Label of an instrument that failed to load (and was replaced), or null. */
+  /** Label of an instrument whose samples failed to load, or null. */
   loadError: string | null;
+  /** Quality of the realization currently in `synthRef`. */
+  activeQuality: AudioQuality;
   /** Dismiss the current load-error notice. */
   dismissError: () => void;
+  /** Re-attempt loading the high-quality samples. */
+  retry: () => void;
 }
 
 export function useInstrument(
   preset: SoundPresetId,
-  { sustainMode, synthRef }: UseInstrumentOptions,
+  options: UseInstrumentOptions<Synth>,
+): UseInstrumentResult;
+export function useInstrument(
+  preset: SoundPresetId,
+  options: UseInstrumentOptions<MelodySynth> & { role: "melody" },
+): UseInstrumentResult;
+export function useInstrument(
+  preset: SoundPresetId,
+  {
+    quality,
+    sustainMode,
+    role = "chord",
+    enabled = true,
+    synthRef,
+  }: UseInstrumentOptions<Playable>,
 ): UseInstrumentResult {
   const [isLoading, setIsLoading] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [activeQuality, setActiveQuality] = useState<AudioQuality>("lightweight");
+  const [retryNonce, setRetryNonce] = useState(0);
 
   useEffect(() => {
+    if (!enabled) {
+      setIsLoading(false);
+      setLoadError(null);
+      setActiveQuality("lightweight");
+      return;
+    }
+
     let cancelled = false;
     let settled = false;
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let disposeTimerId: ReturnType<typeof setTimeout> | null = null;
+    let replaced: Playable | null = null;
+    let highInstrument: Playable | null = null;
 
     const clearTimer = () => {
       if (timeoutId) {
@@ -63,54 +129,82 @@ export function useInstrument(
       }
     };
 
-    /** Swap in the Organ synth and surface a notice naming the failed preset. */
-    const fallBack = () => {
-      if (cancelled || settled) return;
-      settled = true;
-      clearTimer();
-      if (synthRef.current) {
-        synthRef.current.releaseAll();
-        synthRef.current.dispose();
-        synthRef.current = null;
-      }
-      synthRef.current = createSynthForPreset(FALLBACK_PRESET, { sustainMode });
-      setIsLoading(false);
-      setLoadError(INSTRUMENTS[preset].label);
-    };
+    const build = (q: AudioQuality, cbs?: { onLoaded?: () => void; onError?: () => void }) =>
+      role === "melody"
+        ? createMelodySynthForPreset(preset, q, cbs)
+        : createSynthForPreset(preset, q, { sustainMode, ...cbs });
 
-    setIsLoading(presetNeedsLoading(preset));
+    // The lightweight realization is always available synchronously, so the
+    // caller has a playable instrument from the first render.
+    synthRef.current = build("lightweight");
+    setActiveQuality("lightweight");
     setLoadError(null);
 
-    const synth = createSynthForPreset(preset, {
-      sustainMode,
-      onLoaded: () => {
+    const wantHigh = quality === "high" && presetHasHighQuality(preset);
+    setIsLoading(wantHigh);
+
+    if (wantHigh) {
+      const label = INSTRUMENTS[preset].label;
+
+      const fail = () => {
         if (cancelled || settled) return;
         settled = true;
         clearTimer();
+        safeDispose(highInstrument);
+        highInstrument = null;
         setIsLoading(false);
-      },
-      onError: fallBack,
-    });
-    synthRef.current = synth;
+        setLoadError(label);
+      };
 
-    if (presetNeedsLoading(preset)) {
-      timeoutId = setTimeout(fallBack, LOAD_TIMEOUT_MS);
+      highInstrument = build("high", {
+        onLoaded: () => {
+          if (cancelled || settled) return;
+          settled = true;
+          clearTimer();
+          // Hot-swap: future triggers hit the sampler; the lightweight twin
+          // releases its notes and is disposed once its tail has faded.
+          const old = synthRef.current;
+          synthRef.current = highInstrument;
+          if (old && old !== highInstrument) {
+            silence(old);
+            replaced = old;
+            disposeTimerId = setTimeout(() => {
+              safeDispose(replaced);
+              replaced = null;
+            }, SWAP_DISPOSE_DELAY_MS);
+          }
+          setActiveQuality("high");
+          setIsLoading(false);
+        },
+        onError: fail,
+      });
+      timeoutId = setTimeout(fail, LOAD_TIMEOUT_MS);
     }
 
     return () => {
       cancelled = true;
       clearTimer();
+      if (disposeTimerId) clearTimeout(disposeTimerId);
+      safeDispose(replaced);
+      replaced = null;
+      // A sampler still loading (or failed) that never made it into the ref.
+      if (highInstrument && highInstrument !== synthRef.current) {
+        safeDispose(highInstrument);
+      }
+      highInstrument = null;
       if (synthRef.current) {
-        synthRef.current.releaseAll();
-        synthRef.current.dispose();
+        silence(synthRef.current);
+        safeDispose(synthRef.current);
         synthRef.current = null;
       }
     };
-  }, [preset, sustainMode, synthRef]);
+  }, [preset, quality, sustainMode, role, enabled, synthRef, retryNonce]);
 
   return {
     isLoading,
     loadError,
-    dismissError: () => setLoadError(null),
+    activeQuality,
+    dismissError: useCallback(() => setLoadError(null), []),
+    retry: useCallback(() => setRetryNonce((n) => n + 1), []),
   };
 }

--- a/lib/state/__tests__/audioSettingsStore.test.ts
+++ b/lib/state/__tests__/audioSettingsStore.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAudioSettingsStore } from "../audioSettingsStore";
+import { DEFAULT_INSTRUMENT, type SoundPresetId } from "../../audio/instrumentCatalog";
+
+describe("audioSettingsStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useAudioSettingsStore.setState({
+      instrumentId: DEFAULT_INSTRUMENT,
+      quality: "high",
+    });
+  });
+
+  it("defaults to the lush piano in high quality", () => {
+    const state = useAudioSettingsStore.getState();
+    expect(state.instrumentId).toBe(DEFAULT_INSTRUMENT);
+    expect(state.quality).toBe("high");
+  });
+
+  it("updates the instrument", () => {
+    useAudioSettingsStore.getState().setInstrument("filtered-saw");
+    expect(useAudioSettingsStore.getState().instrumentId).toBe("filtered-saw");
+  });
+
+  it("sanitizes unknown instrument ids", () => {
+    useAudioSettingsStore.getState().setInstrument("retired-instrument" as SoundPresetId);
+    expect(useAudioSettingsStore.getState().instrumentId).toBe(DEFAULT_INSTRUMENT);
+  });
+
+  it("updates and sanitizes the quality mode", () => {
+    useAudioSettingsStore.getState().setQuality("lightweight");
+    expect(useAudioSettingsStore.getState().quality).toBe("lightweight");
+    useAudioSettingsStore.getState().setQuality("high");
+    expect(useAudioSettingsStore.getState().quality).toBe("high");
+  });
+
+  it("persists settings to localStorage", () => {
+    useAudioSettingsStore.getState().setInstrument("soft-keys");
+    useAudioSettingsStore.getState().setQuality("lightweight");
+    const raw = localStorage.getItem("harmonia-audio-settings");
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.state.instrumentId).toBe("soft-keys");
+    expect(parsed.state.quality).toBe("lightweight");
+  });
+});

--- a/lib/state/audioSettingsStore.ts
+++ b/lib/state/audioSettingsStore.ts
@@ -1,0 +1,71 @@
+/**
+ * Audio Settings Store
+ *
+ * Holds the user's instrument choice and audio quality mode, persisted to
+ * localStorage so they carry across sessions and are shared by every surface
+ * that plays audio (main progression page, Sketchpad).
+ *
+ * Quality semantics:
+ * - "lightweight" — pure synthesis, no downloads, works offline.
+ * - "high"        — sampled instruments load lazily in the background while
+ *                   the lightweight twin plays, then hot-swap in. Never blocks.
+ *
+ * Defaults to "high" because it no longer delays playback; users who have
+ * enabled their browser's data-saver get "lightweight" on first run.
+ */
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import {
+  DEFAULT_INSTRUMENT,
+  resolvePresetId,
+  type AudioQuality,
+  type SoundPresetId,
+} from "../audio/instrumentCatalog";
+
+function initialQuality(): AudioQuality {
+  if (typeof navigator !== "undefined") {
+    const connection = (navigator as { connection?: { saveData?: boolean } }).connection;
+    if (connection?.saveData) return "lightweight";
+  }
+  return "high";
+}
+
+interface AudioSettingsState {
+  /** Selected instrument sound (identity is independent of quality). */
+  instrumentId: SoundPresetId;
+  /** Playback quality mode. */
+  quality: AudioQuality;
+
+  setInstrument: (id: SoundPresetId) => void;
+  setQuality: (quality: AudioQuality) => void;
+}
+
+export const useAudioSettingsStore = create<AudioSettingsState>()(
+  persist(
+    (set) => ({
+      instrumentId: DEFAULT_INSTRUMENT,
+      quality: initialQuality(),
+
+      setInstrument: (id) => set({ instrumentId: resolvePresetId(id) }),
+      setQuality: (quality) =>
+        set({ quality: quality === "high" ? "high" : "lightweight" }),
+    }),
+    {
+      name: "harmonia-audio-settings",
+      version: 1,
+      // Sanitize persisted values: an instrument id from an older build that
+      // no longer exists must resolve to a valid catalog entry, never crash.
+      merge: (persisted, current) => {
+        const p = (persisted ?? {}) as Partial<AudioSettingsState>;
+        return {
+          ...current,
+          ...p,
+          instrumentId: resolvePresetId(p.instrumentId),
+          quality:
+            p.quality === "lightweight" || p.quality === "high" ? p.quality : current.quality,
+        };
+      },
+    },
+  ),
+);


### PR DESCRIPTION
Documents the current Tone.js-based playback architecture, its
limitations (blocking sample loads, third-party CDN dependency,
non-persistent instrument choice, weak EP samples, no synth pad
voices), and proposes a two-tier Lightweight/High-Quality audio
mode architecture with a phased implementation plan.

https://claude.ai/code/session_016PhEAYL78t3uQJXXvo23AB