### PR TITLE
Restore reliable audio: centralize context unlock + visible status

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Sample loading is resilient by design via the `useInstrument` hook (`lib/audio/u
 
 The acoustic piano uses the [Salamander Grand Piano](https://github.com/sfzinstruments/SalamanderGrandPiano) sample set by Alexander Holm (CC-BY 3.0), served via the Tone.js audio CDN. (The hosted set is single-velocity, so velocity changes loudness rather than timbre — a deliberate trade for fast load, small footprint, and mobile/browser compatibility.)
 
+#### Audio unlock & status
+
+Browsers (especially mobile Safari/Chrome) start the Web Audio context **suspended** and only resume it from a real user gesture. All sound-producing gestures — Play, Generate, chord-card and piano-roll taps, substitution previews, and every Sketchpad control — route through `ensureAudioReady()` in `lib/audio/audioEngine.ts`. It resumes the context from the gesture, is idempotent (concurrent callers share one unlock), waits until the context is actually `running` before notes are triggered, and **never swallows failures**. A small on-screen `AudioStatusBadge` reflects the live state — *Tap any control to enable audio* / *Audio initializing…* / *Audio ready* / *Audio failed: \<reason\>* — so a silent context or a rejected `Tone.start()` is visible instead of mysterious silence. Set `localStorage.harmonia-audio-debug = "1"` (on automatically outside production) for `[audio]` console diagnostics covering context state changes, sample loads, and hot-swaps.
+
 ## Usage
 
 ### Chord Progression Generator

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,6 +27,8 @@ import {
 import type { Synth, MelodySynth } from "@/lib/audio/synthPresets";
 import { useAudioSettingsStore } from "@/lib/state/audioSettingsStore";
 import { useInstrument } from "@/lib/audio/useInstrument";
+import { ensureAudioReady } from "@/lib/audio/audioEngine";
+import { AudioStatusBadge } from "@/components/audio/AudioStatusBadge";
 import { midiToNoteName, normalizeToPitchClass, type PitchClass } from "@/lib/theory/midiUtils";
 import { keyPrefersFlats } from "@/lib/theory/spelling";
 import type { Mode } from "@/lib/theory/harmonyEngine";
@@ -380,9 +382,7 @@ export default function HarmoniaPage() {
   /* ─── Handlers ─── */
 
   const handleGenerate = useCallback(async () => {
-    if (Tone.getContext().state !== "running") {
-      await Tone.start();
-    }
+    await ensureAudioReady();
     if (isPlaying) {
       setIsPlaying(false);
     }
@@ -391,9 +391,9 @@ export default function HarmoniaPage() {
   }, [generateNew, isPlaying, setIsPlaying]);
 
   const handleTogglePlayback = useCallback(async () => {
-    if (Tone.getContext().state !== "running") {
-      await Tone.start();
-    }
+    // Resume from this gesture and wait until the context is actually running
+    // before scheduling, so the first press is never a silent no-op.
+    await ensureAudioReady();
     setIsPlaying(!isPlaying);
   }, [isPlaying, setIsPlaying]);
 
@@ -418,7 +418,10 @@ export default function HarmoniaPage() {
    * Play a one-off chord preview with humanized per-note velocity (no strum,
    * so previews stay snappy). Reads live settings via getState.
    */
-  const playChordPreview = useCallback((notesWithOctave: string[], duration: string) => {
+  const playChordPreview = useCallback(async (notesWithOctave: string[], duration: string) => {
+    // A chord-card / substitution tap is often the first gesture on mobile, so
+    // unlock the context here too — otherwise the preview is silently dropped.
+    await ensureAudioReady();
     if (!synthRef.current) return;
     const ps = usePlaybackSettingsStore.getState();
     const events = buildChordEvents(notesWithOctave, {
@@ -432,7 +435,8 @@ export default function HarmoniaPage() {
   }, []);
 
   const handlePlayNote = useCallback(
-    (noteWithOctave: string) => {
+    async (noteWithOctave: string) => {
+      await ensureAudioReady();
       if (synthRef.current) {
         const ps = usePlaybackSettingsStore.getState();
         const velocity = humanizeVelocity(ps.chordVelocity, ps.humanize);
@@ -444,6 +448,9 @@ export default function HarmoniaPage() {
 
   const handleChordClick = useCallback(
     (notesWithOctave: string[], chordIndex: number) => {
+      // Begin unlocking synchronously while the tap is still "live" (mobile
+      // requires this); playChordPreview awaits the same promise before firing.
+      void ensureAudioReady();
       // Stop current playback to prevent overlapping sounds
       if (isPlaying) {
         setIsPlaying(false);
@@ -466,6 +473,7 @@ export default function HarmoniaPage() {
   // ─── Substitution handlers ───
   const handleSubstitutionPreview = useCallback(
     (option: SubstitutionOption) => {
+      void ensureAudioReady();
       if (synthRef.current) {
         synthRef.current.releaseAll();
         setTimeout(() => {
@@ -479,6 +487,7 @@ export default function HarmoniaPage() {
   const handleSubstitutionApply = useCallback(
     (option: SubstitutionOption) => {
       if (substitutionTarget === null) return;
+      void ensureAudioReady();
       applySubstitution(option, substitutionTarget);
       // Preview the applied chord
       if (synthRef.current) {
@@ -924,7 +933,11 @@ export default function HarmoniaPage() {
               <span className="w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin" />
               <span>Loading high-quality {presetLabel} — playing lightweight sound meanwhile…</span>
             </div>
-          ) : null}
+          ) : (
+            <div className="flex items-center justify-center mb-2 min-h-[1rem]">
+              <AudioStatusBadge />
+            </div>
+          )}
           <div className="flex items-center justify-center gap-1.5 sm:gap-2 lg:gap-3">
 
             {/* Primary: Play / Stop */}

--- a/components/audio/AudioStatusBadge.tsx
+++ b/components/audio/AudioStatusBadge.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+/**
+ * AudioStatusBadge — small, shared indicator that makes the otherwise-invisible
+ * Web Audio state obvious: whether the context still needs a tap to unlock,
+ * is initializing, is ready, or failed. Backed by `useAudioStatusStore`, which
+ * the audio engine updates from every gesture.
+ *
+ * It renders nothing in the steady "ready" state after a moment, so it adds no
+ * clutter once sound is working — it only speaks up when the user needs to know.
+ */
+
+import { useEffect, useState } from "react";
+import { Volume2, VolumeX, AlertTriangle, Loader2 } from "lucide-react";
+import { useAudioStatusStore } from "@/lib/audio/audioEngine";
+
+export function AudioStatusBadge({ className = "" }: { className?: string }) {
+  const status = useAudioStatusStore((s) => s.status);
+  const error = useAudioStatusStore((s) => s.error);
+
+  // Show a brief "Audio ready" confirmation the first time we go live, then
+  // fade out so the steady state is uncluttered.
+  const [showReady, setShowReady] = useState(false);
+  useEffect(() => {
+    if (status !== "ready") return;
+    setShowReady(true);
+    const t = setTimeout(() => setShowReady(false), 2200);
+    return () => clearTimeout(t);
+  }, [status]);
+
+  if (status === "ready" && !showReady) return null;
+
+  const base =
+    "inline-flex items-center justify-center gap-1.5 text-xs " + className;
+
+  if (status === "failed") {
+    return (
+      <div className={base + " text-red-600 dark:text-red-400"} role="status" aria-live="polite">
+        <AlertTriangle className="w-3.5 h-3.5" />
+        <span>Audio failed{error ? `: ${error}` : ""}</span>
+      </div>
+    );
+  }
+
+  if (status === "initializing") {
+    return (
+      <div className={base + " text-muted"} role="status" aria-live="polite">
+        <Loader2 className="w-3.5 h-3.5 animate-spin" />
+        <span>Audio initializing…</span>
+      </div>
+    );
+  }
+
+  if (status === "idle") {
+    return (
+      <div className={base + " text-muted"} role="status" aria-live="polite">
+        <VolumeX className="w-3.5 h-3.5" />
+        <span>Tap any control to enable audio</span>
+      </div>
+    );
+  }
+
+  // status === "ready" (briefly)
+  return (
+    <div className={base + " text-emerald-600 dark:text-emerald-400"} role="status" aria-live="polite">
+      <Volume2 className="w-3.5 h-3.5" />
+      <span>Audio ready</span>
+    </div>
+  );
+}

--- a/components/sketchpad/HarmonicPreviewPanel.tsx
+++ b/components/sketchpad/HarmonicPreviewPanel.tsx
@@ -24,6 +24,7 @@ import type {
 } from "@/lib/sketchpad/types";
 import type { Mode } from "@/lib/theory/harmonyEngine";
 import { SOUND_PRESETS, type SoundPresetId } from "@/lib/audio/instrumentCatalog";
+import { AudioStatusBadge } from "@/components/audio/AudioStatusBadge";
 import clsx from "clsx";
 
 const MODES: { value: Mode; label: string }[] = [
@@ -149,6 +150,8 @@ export function HarmonicPreviewPanel({
             </button>
           </div>
         )}
+
+        <AudioStatusBadge className="mb-2" />
 
         {/* Playback controls */}
         <div className="flex flex-wrap gap-1.5">

--- a/components/sketchpad/Workspace.tsx
+++ b/components/sketchpad/Workspace.tsx
@@ -10,6 +10,7 @@ import { HarmonicPreviewPanel } from "./HarmonicPreviewPanel";
 import { type Synth } from "@/lib/audio/synthPresets";
 import { useAudioSettingsStore } from "@/lib/state/audioSettingsStore";
 import { useInstrument } from "@/lib/audio/useInstrument";
+import { ensureAudioReady } from "@/lib/audio/audioEngine";
 
 function beatsToDuration(beats: number): string {
   switch (beats) {
@@ -127,7 +128,7 @@ export function SketchpadWorkspace({ project }: { project: HarmonicSketchProject
   // Play single chord
   const playChord = useCallback(
     async (event: HarmonicEvent) => {
-      if (Tone.getContext().state !== "running") await Tone.start();
+      await ensureAudioReady();
       stopPlayback();
       if (!synthRef.current) return;
       const notes = event.notesWithOctave.length > 0 ? event.notesWithOctave : event.notes.map((n) => `${n}3`);
@@ -139,7 +140,7 @@ export function SketchpadWorkspace({ project }: { project: HarmonicSketchProject
   // Play section
   const playSection = useCallback(
     async (section: HarmonicSection, loop: boolean = false) => {
-      if (Tone.getContext().state !== "running") await Tone.start();
+      await ensureAudioReady();
       stopPlayback();
       const variant = section.variants.find((v) => v.id === section.activeVariantId);
       if (!variant || variant.events.length === 0) return;
@@ -154,7 +155,7 @@ export function SketchpadWorkspace({ project }: { project: HarmonicSketchProject
   // Play full song
   const playFullSong = useCallback(
     async (startFromSectionIndex: number = 0) => {
-      if (Tone.getContext().state !== "running") await Tone.start();
+      await ensureAudioReady();
       stopPlayback();
 
       const allEvents: { event: HarmonicEvent; sectionIndex: number; eventIndex: number }[] = [];
@@ -218,7 +219,7 @@ export function SketchpadWorkspace({ project }: { project: HarmonicSketchProject
   // Play transition preview between two sections
   const playTransition = useCallback(
     async (fromSection: HarmonicSection, toSection: HarmonicSection) => {
-      if (Tone.getContext().state !== "running") await Tone.start();
+      await ensureAudioReady();
       stopPlayback();
       const fromVariant = fromSection.variants.find((v) => v.id === fromSection.activeVariantId);
       const toVariant = toSection.variants.find((v) => v.id === toSection.activeVariantId);
@@ -237,7 +238,8 @@ export function SketchpadWorkspace({ project }: { project: HarmonicSketchProject
   );
 
   const playNote = useCallback(
-    (noteWithOctave: string) => {
+    async (noteWithOctave: string) => {
+      await ensureAudioReady();
       if (synthRef.current) {
         synthRef.current.triggerAttackRelease(noteWithOctave, "4n");
       }

--- a/lib/audio/__tests__/audioEngine.test.ts
+++ b/lib/audio/__tests__/audioEngine.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for the audio engine's unlock + status state machine. Tone.js is
+ * mocked so we can drive the AudioContext state deterministically and assert
+ * that silent failures become visible status transitions.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/** Mutable fake AudioContext state the mock reads from. */
+const ctx = { state: "suspended" as AudioContextState };
+const startMock = vi.fn(async () => {
+  ctx.state = "running";
+});
+const resumeMock = vi.fn(async () => {
+  ctx.state = "running";
+});
+
+vi.mock("tone", () => ({
+  start: () => startMock(),
+  getContext: () => ({
+    get state() {
+      return ctx.state;
+    },
+    resume: () => resumeMock(),
+    rawContext: { addEventListener: vi.fn() },
+  }),
+}));
+
+async function freshEngine() {
+  vi.resetModules();
+  return import("../audioEngine");
+}
+
+beforeEach(() => {
+  ctx.state = "suspended";
+  startMock.mockClear();
+  resumeMock.mockClear();
+  startMock.mockImplementation(async () => {
+    ctx.state = "running";
+  });
+});
+
+describe("ensureAudioReady", () => {
+  it("resumes a suspended context and reports ready", async () => {
+    const { ensureAudioReady, useAudioStatusStore } = await freshEngine();
+
+    const ok = await ensureAudioReady();
+
+    expect(ok).toBe(true);
+    expect(startMock).toHaveBeenCalledTimes(1);
+    expect(useAudioStatusStore.getState().status).toBe("ready");
+    expect(useAudioStatusStore.getState().error).toBeNull();
+  });
+
+  it("is idempotent and does not re-start an already-running context", async () => {
+    const { ensureAudioReady } = await freshEngine();
+
+    await ensureAudioReady();
+    await ensureAudioReady();
+
+    expect(startMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares a single in-flight unlock between concurrent callers", async () => {
+    const { ensureAudioReady } = await freshEngine();
+
+    const [a, b] = await Promise.all([ensureAudioReady(), ensureAudioReady()]);
+
+    expect(a).toBe(true);
+    expect(b).toBe(true);
+    expect(startMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces a failure (does not swallow it) when Tone.start rejects", async () => {
+    const { ensureAudioReady, useAudioStatusStore } = await freshEngine();
+    startMock.mockImplementation(async () => {
+      throw new Error("NotAllowedError");
+    });
+
+    const ok = await ensureAudioReady();
+
+    expect(ok).toBe(false);
+    expect(useAudioStatusStore.getState().status).toBe("failed");
+    expect(useAudioStatusStore.getState().error).toContain("NotAllowedError");
+  });
+
+  it("reports failed when the context stays suspended after starting", async () => {
+    const { ensureAudioReady, useAudioStatusStore } = await freshEngine();
+    // Neither start nor resume manages to flip the context to running.
+    startMock.mockImplementation(async () => {});
+    resumeMock.mockImplementation(async () => {});
+
+    const ok = await ensureAudioReady();
+
+    expect(ok).toBe(false);
+    expect(useAudioStatusStore.getState().status).toBe("failed");
+    expect(useAudioStatusStore.getState().error).toContain("suspended");
+  });
+});

--- a/lib/audio/audioEngine.ts
+++ b/lib/audio/audioEngine.ts
@@ -1,0 +1,191 @@
+/**
+ * audioEngine — single entry point for unlocking and observing the Web Audio
+ * context, with explicit status and development diagnostics.
+ *
+ * Why this exists
+ * ---------------
+ * Browsers (especially mobile Safari/Chrome) start every AudioContext in a
+ * `suspended` state and only let it resume from inside a real user gesture.
+ * Tone.js exposes `Tone.start()` for this, but it must be:
+ *   1. called from a gesture handler (a click/tap), and
+ *   2. awaited before notes are triggered, or the notes hit a suspended
+ *      context and produce **no sound and no error** — a silent failure.
+ *
+ * Previously only the Play and Generate buttons resumed the context; every
+ * "preview" gesture (tapping a chord card, a piano-roll key, a substitution)
+ * triggered the synth directly. On desktop the context often resumes leniently
+ * so this was masked, but on mobile the first tap is frequently a preview, so
+ * audio silently never started.
+ *
+ * `ensureAudioReady()` centralises the unlock: it is idempotent, safe to call
+ * from any gesture, surfaces failures through `useAudioStatusStore`, and logs
+ * diagnostics so silent failures become visible. Call it at the top of every
+ * gesture that makes sound, then await it before triggering notes.
+ */
+
+import * as Tone from "tone";
+import { create } from "zustand";
+
+/* ─── User-visible status ─── */
+
+export type AudioStatus =
+  /** No sound attempted yet; context is suspended. "Tap to enable audio." */
+  | "idle"
+  /** `Tone.start()` in flight. "Audio initializing…" */
+  | "initializing"
+  /** Context is running; playback will be audible. "Audio ready." */
+  | "ready"
+  /** Unlock failed or the context is stuck. "Audio failed: <reason>." */
+  | "failed";
+
+interface AudioStatusState {
+  status: AudioStatus;
+  /** Human-readable reason when `status === "failed"`, else null. */
+  error: string | null;
+  set: (status: AudioStatus, error?: string | null) => void;
+}
+
+/**
+ * Reactive audio status, consumed by the on-screen audio indicator. Kept in a
+ * tiny store (not React state) so non-React modules — the engine itself, the
+ * instrument hook — can update it from anywhere.
+ */
+export const useAudioStatusStore = create<AudioStatusState>((set) => ({
+  status: "idle",
+  error: null,
+  set: (status, error = null) => set({ status, error }),
+}));
+
+function setStatus(status: AudioStatus, error: string | null = null): void {
+  useAudioStatusStore.getState().set(status, error);
+}
+
+/* ─── Diagnostics ─── */
+
+const DEBUG_STORAGE_KEY = "harmonia-audio-debug";
+
+/**
+ * Console diagnostics are on automatically outside production and can be
+ * toggled in any build with `localStorage.harmonia-audio-debug = "1"`.
+ */
+export function audioDebugEnabled(): boolean {
+  if (process.env.NODE_ENV !== "production") return true;
+  if (typeof window !== "undefined") {
+    try {
+      return window.localStorage.getItem(DEBUG_STORAGE_KEY) === "1";
+    } catch {
+      /* private mode / storage disabled */
+    }
+  }
+  return false;
+}
+
+/** Namespaced, level-tagged logger gated behind {@link audioDebugEnabled}. */
+export function audioDebug(...args: unknown[]): void {
+  if (audioDebugEnabled()) {
+    // eslint-disable-next-line no-console
+    console.info("[audio]", ...args);
+  }
+}
+
+/** Warnings are always logged — a swallowed audio error helps nobody. */
+export function audioWarn(...args: unknown[]): void {
+  // eslint-disable-next-line no-console
+  console.warn("[audio]", ...args);
+}
+
+/* ─── Context helpers ─── */
+
+/** Current AudioContext state, or "unknown" if Tone hasn't created one yet. */
+export function getAudioContextState(): AudioContextState | "unknown" {
+  try {
+    return Tone.getContext().state as AudioContextState;
+  } catch {
+    return "unknown";
+  }
+}
+
+let stateSubscribed = false;
+
+/**
+ * Keep {@link useAudioStatusStore} in sync if the context is suspended later
+ * (e.g. the tab is backgrounded on mobile, then foregrounded). Attaches once.
+ */
+export function subscribeAudioContextState(): void {
+  if (stateSubscribed) return;
+  stateSubscribed = true;
+  try {
+    const raw = Tone.getContext().rawContext as unknown as AudioContext;
+    raw.addEventListener?.("statechange", () => {
+      const state = getAudioContextState();
+      audioDebug("context statechange →", state);
+      if (state === "running") {
+        setStatus("ready");
+      } else if (state === "suspended" || state === "closed") {
+        // Don't clobber an in-flight initialize or a hard failure.
+        const current = useAudioStatusStore.getState().status;
+        if (current === "ready") setStatus("idle");
+      }
+    });
+  } catch {
+    /* no context yet; ensureAudioReady will create and resume it */
+  }
+}
+
+/* ─── The unlock ─── */
+
+let pending: Promise<boolean> | null = null;
+
+/**
+ * Resume the AudioContext, returning whether it is running afterwards. Safe to
+ * call repeatedly and from any gesture; concurrent callers share one attempt.
+ *
+ * Call it **synchronously at the top of a gesture handler** (so the gesture is
+ * still "live" for mobile unlock), then `await` the returned promise before
+ * triggering notes.
+ */
+export async function ensureAudioReady(): Promise<boolean> {
+  subscribeAudioContextState();
+
+  if (getAudioContextState() === "running") {
+    setStatus("ready");
+    return true;
+  }
+  if (pending) return pending;
+
+  setStatus("initializing");
+  audioDebug("ensureAudioReady → starting (context:", getAudioContextState() + ")");
+
+  pending = (async () => {
+    try {
+      await Tone.start();
+      // Some mobile contexts ignore the first resume; nudge once more.
+      if (getAudioContextState() !== "running") {
+        try {
+          await Tone.getContext().resume();
+        } catch {
+          /* fall through to the state check below */
+        }
+      }
+      const running = getAudioContextState() === "running";
+      if (running) {
+        audioDebug("audio ready — context running");
+        setStatus("ready");
+      } else {
+        const reason = `context ${getAudioContextState()}`;
+        audioWarn("Tone.start resolved but context is not running:", getAudioContextState());
+        setStatus("failed", reason);
+      }
+      return running;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      audioWarn("Tone.start failed:", message);
+      setStatus("failed", message);
+      return false;
+    } finally {
+      pending = null;
+    }
+  })();
+
+  return pending;
+}

--- a/lib/audio/useInstrument.ts
+++ b/lib/audio/useInstrument.ts
@@ -19,6 +19,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import type { SustainMode } from "./humanization";
+import { audioDebug, audioWarn } from "./audioEngine";
 import { presetHasHighQuality, type AudioQuality } from "./instrumentCatalog";
 import {
   INSTRUMENTS,
@@ -146,7 +147,9 @@ export function useInstrument(
     if (wantHigh) {
       const label = INSTRUMENTS[preset].label;
 
-      const fail = () => {
+      audioDebug(`loading high-quality samples for "${label}" (${role})`);
+
+      const fail = (reason?: unknown) => {
         if (cancelled || settled) return;
         settled = true;
         clearTimer();
@@ -154,6 +157,12 @@ export function useInstrument(
         highInstrument = null;
         setIsLoading(false);
         setLoadError(label);
+        // Surface the swallowed error: the UI keeps playing the lightweight
+        // twin, but the reason the samples never arrived should not vanish.
+        audioWarn(
+          `high-quality samples for "${label}" failed — using lightweight voice.`,
+          reason ?? "(load timed out)",
+        );
       };
 
       highInstrument = build("high", {
@@ -161,6 +170,7 @@ export function useInstrument(
           if (cancelled || settled) return;
           settled = true;
           clearTimer();
+          audioDebug(`high-quality "${label}" loaded — hot-swapping in`);
           // Hot-swap: future triggers hit the sampler; the lightweight twin
           // releases its notes and is disposed once its tail has faded.
           const old = synthRef.current;


### PR DESCRIPTION
Preview gestures (chord-card taps, piano-roll keys, substitution
previews, Sketchpad playNote) triggered the synth without ever resuming
the AudioContext. Browsers — mobile Safari/Chrome especially — start the
context suspended and only resume it from a real gesture, so these taps
produced no sound and no error. On mobile the first tap is often a
preview, so audio silently never started.

- Add lib/audio/audioEngine.ts: ensureAudioReady() resumes the context
  from the gesture, is idempotent, waits until the context is actually
  running before notes fire, retries a stubborn resume once, and routes
  every failure into a status store instead of swallowing it. Plus an
  audioDebug/audioWarn diagnostics layer (auto-on outside production;
  localStorage harmonia-audio-debug=1 to force).
- Route every sound-producing gesture on the main page and Sketchpad
  through ensureAudioReady(); kick the unlock synchronously for handlers
  that defer the trigger via setTimeout so the gesture stays live.
- Add AudioStatusBadge: Tap to enable / initializing / ready / failed.
- Surface swallowed sample-load failures in useInstrument via audioWarn.
- Tests for the unlock state machine; README documents the flow.