### PR TITLE
feat: add scale-snapped melody editor and harmonization engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ Two complementary forms of control for refining generated progressions:
 - **Manual Chord Substitution** — Click any chord card to open a substitution panel with theory-approved alternatives. Options are grouped by category (diatonic, relative, dominant-function, tritone, modal mixture, inversion) with explanations of why each works. Preview before applying, and revert any time.
 - **Interactive Piano Roll Editing** — Double-click empty grid cells to add notes, double-click existing notes to remove them. Tap/click a note to select it, then move it up/down to the next in-key note with the ▲/▼ steppers or Arrow keys; on desktop you can also drag notes vertically for free chromatic placement. On mobile the roll scrolls naturally (drag is desktop-only), so editing stays precise. Harmonia re-interprets the chord label in real time after edits. Source badges (Generated, Substituted, Edited) track the provenance of each chord. Reset any chord to its original state.
 
+### Melody Drawing & Harmonization
+
+Draw a melody directly in a scale-snapped piano roll, then let Harmonia find chords that fit it — a DAW-style "melody first, chords second" workflow.
+
+- **Scale-snapped melody editor** — Pick a key/scale (e.g. D minor) and the editor highlights the in-scale rows, de-emphasizes the rest, and snaps every note you place to the scale. Clear bar/beat grid lines and a note-length selector (1/16, 1/8, 1/4, 1/2, whole) keep timing precise.
+- **Full note editing** — Tap an empty cell to add a note, drag a note to move it (pitch snaps to the scale, timing quantizes to 1/16), drag the right edge to resize, and Delete/⌫ or the trash button to remove the selected note. A properties readout shows the selected note's pitch, start beat, and duration. Touch-friendly: large targets, drag-to-move, a visible resize handle, and ▲/▼ in-key steppers.
+- **Harmonize Melody** — One click runs a deterministic, rule-based harmonizer: it builds the diatonic chords for the key, splits the melody into one-bar regions, weights the important melody notes (strong beats, long notes, downbeats, phrase ends, repeats), scores each diatonic chord against each region, and picks a progression with smooth, functional motion (tonic → predominant → dominant → tonic). A melody in D minor typically yields results like **Dm – Bb – C – Dm**.
+- **Explainable results** — Each generated chord comes with a plain-language reason (e.g. *"Dm fits because your melody emphasizes D, F, and A."*), shown above the progression. The chords drop straight into the existing progression UI, piano roll, and playback, so the melody and chords play together immediately.
+- **Style hooks** — The engine ships with `bestFit` plus `darker`, `brighter`, `tense`, and `simple` flavours (the UI currently triggers Best Fit; the others are available via the harmonizer API).
+
 ### Harmonic Sketchpad
 
 A song-level harmonic planning workspace for sketching the harmonic architecture of a full song before opening a DAW.
@@ -112,6 +122,15 @@ Browsers (especially mobile Safari/Chrome) start the Web Audio context **suspend
 9. **Double-click** the piano roll grid to add or remove individual notes — chord labels update automatically
 10. Click **Melody** to generate a melody line — choose a style (Lyrical, Rhythmic, Arpeggio), a harmony mode (**Expressive** or **Strict**), and a mood (**Dark**, **Emotional**, **Dreamy**, **Energetic**), then click **Melody** again for a new line. Use the **Audio** button in the action bar to mute/unmute chords and melody and to adjust playback feel — **Velocity**, **Humanize**, **Sustain**, and **Soft Strum** vs **Block Chord**
 11. Click **Save** to bookmark a progression to your favorites. Click **Favorites** to view, load, or remove saved progressions, and the **✕** in the panel (or the Favorites button again) to hide it
+
+### Draw a Melody & Harmonize It
+
+1. Pick a **key** and **mode** (e.g. D minor) so the editor knows which notes are in the scale
+2. Click **Draw** in the action bar to open the scale-snapped melody editor
+3. Choose a **note length** (1/16 → whole), then **tap the grid** to place notes — they snap to the selected scale automatically
+4. **Drag** a note to move it (pitch snaps to the scale, timing quantizes to 1/16), **drag its right edge** to resize, and select a note then press **Delete** (or the trash button / ▲▼ steppers) to edit it
+5. Click **Harmonize Melody** — Harmonia analyzes the melody and generates a chord progression underneath it (a D-minor melody often produces something like **Dm – Bb – C – Dm**)
+6. The chords appear in the normal progression UI with a short explanation of **why each chord was chosen**; hit **Play** to hear the melody and chords together
 
 ### Harmonic Sketchpad
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -778,6 +778,240 @@
   background: rgba(255, 255, 255, 0.3);
 }
 
+/* ─────────────────────────────────────────────
+   SCALE-SNAPPED MELODY EDITOR
+───────────────────────────────────────────── */
+
+.melody-editor {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.melody-editor-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.melody-editor-lengths {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.melody-editor-toolbar-label {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  margin-right: 2px;
+}
+
+.melody-editor-length-btn {
+  min-width: 40px;
+  height: 32px;
+  padding: 0 8px;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface);
+  color: var(--muted);
+  border-radius: 8px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  font-family: var(--font-geist-mono), monospace;
+  transition: all 0.12s;
+}
+.melody-editor-length-btn:hover {
+  border-color: var(--vert-accent-coral);
+  color: var(--foreground);
+}
+.melody-editor-length-btn-active {
+  background: var(--vert-accent-coral);
+  border-color: var(--vert-accent-coral);
+  color: #fff;
+}
+
+.melody-editor-selected {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.melody-editor-selected-info {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.72rem;
+}
+.melody-editor-hint-inline {
+  font-size: 0.7rem;
+  color: var(--muted);
+}
+
+.melody-editor-icon-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface);
+  color: var(--muted);
+  border-radius: 8px;
+  transition: all 0.12s;
+}
+.melody-editor-icon-btn:hover {
+  border-color: var(--vert-accent-coral);
+  color: var(--vert-accent-coral);
+}
+.melody-editor-delete-btn:hover {
+  border-color: #dc2626;
+  color: #dc2626;
+}
+
+.melody-editor-wrap {
+  display: flex;
+  border: 1px solid var(--border-subtle);
+  border-radius: 7px;
+  overflow: hidden;
+  background: var(--vert-key-white);
+  max-width: 100%;
+}
+
+/* Left pitch keyboard */
+.melody-editor-keys {
+  width: 48px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border-subtle);
+  background: var(--surface);
+}
+.melody-editor-key {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 5px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.04);
+  background: var(--vert-key-white);
+}
+.melody-editor-key.black {
+  background: #e8e6df;
+}
+.melody-editor-key.in-scale {
+  background: var(--vert-accent-light);
+}
+.melody-editor-key.tonic {
+  background: rgba(62, 168, 152, 0.22);
+}
+.melody-editor-key-label {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.5rem;
+  color: var(--muted);
+  line-height: 1;
+  pointer-events: none;
+}
+
+/* Grid */
+.melody-editor-grid {
+  position: relative;
+  flex: 1;
+  overflow: hidden;
+  touch-action: none; /* pointer drags drive editing, not scroll */
+}
+.melody-editor-row {
+  position: absolute;
+  left: 0;
+  right: 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.04);
+}
+.melody-editor-row.off-scale {
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(0, 0, 0, 0.025),
+    rgba(0, 0, 0, 0.025) 4px,
+    transparent 4px,
+    transparent 8px
+  );
+}
+.melody-editor-row.in-scale {
+  background: rgba(212, 113, 79, 0.05);
+}
+.melody-editor-row.tonic {
+  background: rgba(62, 168, 152, 0.1);
+}
+
+.melody-editor-beat-line {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: rgba(0, 0, 0, 0.06);
+  pointer-events: none;
+}
+.melody-editor-beat-line.strong {
+  background: rgba(0, 0, 0, 0.16);
+  width: 2px;
+}
+
+.melody-editor-surface {
+  position: absolute;
+  inset: 0;
+  cursor: crosshair;
+  z-index: 1;
+}
+
+.melody-editor-note {
+  position: absolute;
+  background: var(--vert-accent-coral);
+  border-radius: 3px;
+  min-width: 6px;
+  display: flex;
+  align-items: center;
+  padding-left: 4px;
+  cursor: grab;
+  z-index: 2;
+  touch-action: none;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.18), inset 0 1px 0 rgba(255, 255, 255, 0.25);
+  transition: filter 0.08s;
+}
+.melody-editor-note:hover {
+  filter: brightness(1.08);
+  z-index: 3;
+}
+.melody-editor-note:active {
+  cursor: grabbing;
+}
+.melody-editor-note.selected {
+  outline: 2px solid #fff;
+  box-shadow: 0 0 0 3px var(--vert-accent-coral), 0 0 8px rgba(232, 133, 106, 0.4);
+  z-index: 4;
+}
+.melody-editor-note-label {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.5rem;
+  color: #fff;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+  overflow: hidden;
+  pointer-events: none;
+}
+.melody-editor-resize {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 12px;
+  cursor: ew-resize;
+  border-radius: 0 3px 3px 0;
+  touch-action: none;
+}
+.melody-editor-resize:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
 /* ── Custom Range Input (BPM slider) ── */
 input[type="range"] {
   -webkit-appearance: none;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import * as Tone from "tone";
 import { motion, AnimatePresence } from "framer-motion";
-import { Play, Square, Download, Sparkles, Music, Lock, Unlock, LayoutDashboard, Shuffle, RotateCcw, ChevronDown, Heart, Trash2, Upload, VolumeX, Volume2, Settings2, Layers, Save, MoreVertical, X, Check } from "lucide-react";
+import { Play, Square, Download, Sparkles, Music, Lock, Unlock, LayoutDashboard, Shuffle, RotateCcw, ChevronDown, Heart, Trash2, Upload, VolumeX, Volume2, Settings2, Layers, Save, MoreVertical, X, Check, Pencil, Wand2 } from "lucide-react";
 import Link from "next/link";
 import { useProgressionStore, COMPLEXITY_LABELS, getScalePitchClasses, type ComplexityLevel } from "@/lib/state/progressionStore";
 import {
@@ -13,6 +13,7 @@ import {
 } from "@/lib/state/playbackSettingsStore";
 import { buildChordEvents, humanizeVelocity } from "@/lib/audio/humanization";
 import { InteractivePianoRoll } from "@/components/creative/InteractivePianoRoll";
+import { MelodyEditor } from "@/components/creative/MelodyEditor";
 import { ChordCard } from "@/components/progression/ChordCard";
 import { SubstitutionPanel } from "@/components/creative/SubstitutionPanel";
 import { VoicingFeedback } from "@/components/feedback/VoicingFeedback";
@@ -125,6 +126,14 @@ export default function HarmoniaPage() {
     setMelodyHarmony,
     setMelodyMood,
     generateMelodyForProgression,
+    // Drawn melody + harmonization
+    harmonizeDrawnMelody,
+    harmonizationExplanations,
+    clearMelody,
+    addMelodyNote,
+    moveMelodyNote,
+    resizeMelodyNote,
+    deleteMelodyNote,
   } = useProgressionStore();
 
   const { favorites, addFavorite, removeFavorite } = useFavoritesStore();
@@ -156,6 +165,7 @@ export default function HarmoniaPage() {
   const [audioMenuOpen, setAudioMenuOpen] = useState(false);
   const [settingsExpanded, setSettingsExpanded] = useState(false);
   const [showMelodyOnRoll, setShowMelodyOnRoll] = useState(true);
+  const [showMelodyEditor, setShowMelodyEditor] = useState(false);
   const [justSaved, setJustSaved] = useState(false);
 
   const presetLabel = SOUND_PRESETS.find((p) => p.id === soundPreset)?.label ?? "Instrument";
@@ -182,7 +192,7 @@ export default function HarmoniaPage() {
   useInstrument(soundPreset, {
     quality: audioQuality,
     role: "melody",
-    enabled: melodyEnabled,
+    enabled: melodyEnabled || (!!melody && melody.notes.length > 0),
     synthRef: melodySynthRef,
   });
 
@@ -219,7 +229,8 @@ export default function HarmoniaPage() {
   const scheduleIdsRef = useRef<number[]>([]);
 
   useEffect(() => {
-    if (!isPlaying || !currentProgression) {
+    const hasMelody = !!melody && melody.notes.length > 0;
+    if (!isPlaying || (!currentProgression && !hasMelody)) {
       // Clear all scheduled events
       for (const id of scheduleIdsRef.current) {
         Tone.getTransport().clear(id);
@@ -233,13 +244,20 @@ export default function HarmoniaPage() {
       return;
     }
 
-    const chords = currentProgression.chords;
+    const chords = currentProgression?.chords ?? [];
     const ids: number[] = [];
 
-    // Calculate total beats in the progression for looping
+    // Calculate total beats — from the chords if present, otherwise from the
+    // drawn melody (rounded up to whole bars) so a melody alone can loop too.
     let totalBeats = 0;
     for (const chord of chords) {
       totalBeats += durationToBeats(chord.durationClass);
+    }
+    if (totalBeats === 0 && hasMelody) {
+      const melodyEnd = melody!.notes.reduce(
+        (max, n) => Math.max(max, n.startBeat + n.durationBeats), 0
+      );
+      totalBeats = Math.max(4, Math.ceil(melodyEnd / 4) * 4);
     }
     const releaseBuffer = 1; // 1 beat buffer for note release tails
     const totalMeasures = Math.ceil((totalBeats + releaseBuffer) / 4); // in Tone.js "measures" at 4/4
@@ -400,6 +418,30 @@ export default function HarmoniaPage() {
     generateNew();
     setGenerationKey((k) => k + 1);
   }, [generateNew, isPlaying, setIsPlaying]);
+
+  const handleToggleMelodyEditor = useCallback(() => {
+    setShowMelodyEditor((open) => {
+      const next = !open;
+      // Entering draw mode un-mutes the melody voice so drawn notes are audible.
+      if (next && !melodyEnabled) setMelodyEnabled(true);
+      return next;
+    });
+  }, [melodyEnabled, setMelodyEnabled]);
+
+  const handleHarmonize = useCallback(async () => {
+    await ensureAudioReady();
+    if (isPlaying) setIsPlaying(false);
+    harmonizeDrawnMelody("bestFit");
+    setGenerationKey((k) => k + 1);
+  }, [harmonizeDrawnMelody, isPlaying, setIsPlaying]);
+
+  const handleAddMelodyNote = useCallback(
+    (note: Parameters<typeof addMelodyNote>[0]) => {
+      addMelodyNote(note);
+      if (!melodyEnabled) setMelodyEnabled(true);
+    },
+    [addMelodyNote, melodyEnabled, setMelodyEnabled]
+  );
 
   const handleTogglePlayback = useCallback(async () => {
     // Resume from this gesture and wait until the context is actually running
@@ -947,7 +989,7 @@ export default function HarmoniaPage() {
             {/* Primary: Play / Stop */}
             <button
               onClick={handleTogglePlayback}
-              disabled={!currentProgression}
+              disabled={!currentProgression && !(melody && melody.notes.length > 0)}
               className={`flex items-center justify-center gap-1.5 px-4 lg:px-6 py-2.5 rounded-full font-semibold text-sm transition-all duration-200 disabled:opacity-40 shrink-0 ${
                 isPlaying
                   ? "bg-surface text-foreground border border-border-subtle shadow-inner"
@@ -985,6 +1027,30 @@ export default function HarmoniaPage() {
               <Sparkles className="w-4 h-4 text-accent" />
               Melody
             </button>
+
+            {/* Secondary: Draw Melody (toggle the scale-snapped editor) */}
+            <button
+              onClick={handleToggleMelodyEditor}
+              className={`flex items-center justify-center gap-1.5 px-3 lg:px-4 py-2.5 rounded-full border font-medium text-sm transition-all active:scale-95 shrink-0 ${
+                showMelodyEditor
+                  ? "border-accent/40 bg-accent/10 text-accent"
+                  : "border-border-subtle bg-surface text-foreground hover:bg-surface-muted hover:border-accent/40"
+              }`}
+            >
+              <Pencil className="w-4 h-4" />
+              Draw
+            </button>
+
+            {/* Secondary: Harmonize the drawn melody */}
+            {melody && melody.notes.length > 0 && (
+              <button
+                onClick={handleHarmonize}
+                className="flex items-center justify-center gap-1.5 px-3 lg:px-4 py-2.5 rounded-full border border-accent/40 bg-accent/10 text-accent font-medium text-sm hover:bg-accent/20 transition-all active:scale-95 shrink-0"
+              >
+                <Wand2 className="w-4 h-4" />
+                Harmonize
+              </button>
+            )}
 
             {/* Tertiary: Save */}
             <button
@@ -1233,6 +1299,73 @@ export default function HarmoniaPage() {
           </div>
         </section>
 
+        {/* ── Scale-Snapped Melody Editor (draw a melody, then harmonize) ── */}
+        <AnimatePresence>
+          {showMelodyEditor && (
+            <motion.section
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: "auto" }}
+              exit={{ opacity: 0, height: 0 }}
+              transition={{ duration: 0.2 }}
+              className="overflow-hidden"
+            >
+              <div className="bg-surface/60 rounded-2xl p-4 space-y-3">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <Pencil className="w-4 h-4 text-accent" />
+                    <h2 className="text-sm font-semibold tracking-tight">Draw Melody</h2>
+                    <span className="text-xs text-muted">
+                      {rootKey} {MODES.find((m) => m.value === mode)?.label}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {melody && melody.notes.length > 0 && (
+                      <button
+                        onClick={() => clearMelody()}
+                        className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-border-subtle bg-surface text-xs font-medium text-muted hover:text-foreground hover:border-accent/40 transition-colors"
+                        title="Clear melody"
+                      >
+                        <Trash2 className="w-3.5 h-3.5" />
+                        Clear
+                      </button>
+                    )}
+                    <button
+                      onClick={handleHarmonize}
+                      disabled={!melody || melody.notes.length === 0}
+                      className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-accent/40 bg-accent/10 text-accent text-xs font-semibold hover:bg-accent/20 transition-colors disabled:opacity-40"
+                      title="Generate chords that fit your melody"
+                    >
+                      <Wand2 className="w-3.5 h-3.5" />
+                      Harmonize Melody
+                    </button>
+                  </div>
+                </div>
+
+                <MelodyEditor
+                  melodyNotes={melody?.notes ?? []}
+                  scalePitchClasses={getScalePitchClasses(rootKey, mode)}
+                  rootKey={(normalizeToPitchClass(rootKey) || "C") as PitchClass}
+                  useFlats={keyPrefersFlats((normalizeToPitchClass(rootKey) || "C") as PitchClass, mode)}
+                  bars={4}
+                  beatsPerBar={4}
+                  onAddNote={handleAddMelodyNote}
+                  onMoveNote={moveMelodyNote}
+                  onResizeNote={resizeMelodyNote}
+                  onDeleteNote={deleteMelodyNote}
+                  onPlayNote={handlePlayNote}
+                />
+
+                <p className="text-[11px] text-muted/70">
+                  Tap the grid to place a note · drag to move (pitch snaps to the
+                  scale) · drag the right edge to resize · Delete to remove · then{" "}
+                  <span className="font-medium text-foreground">Harmonize Melody</span> to
+                  generate chords.
+                </p>
+              </div>
+            </motion.section>
+          )}
+        </AnimatePresence>
+
         {/* ── Chord Cards + Piano Roll + Creative Tools ── */}
         <section>
           <AnimatePresence mode="wait">
@@ -1286,6 +1419,26 @@ export default function HarmoniaPage() {
                     );
                   })}
                 </div>
+
+                {/* Harmonization rationale — why each chord was chosen for the
+                    drawn melody. Shown only after a Harmonize Melody run. */}
+                {harmonizationExplanations.length > 0 && (
+                  <div className="rounded-xl border border-accent/20 bg-accent/5 px-3 py-2.5">
+                    <div className="flex items-center gap-1.5 mb-1.5">
+                      <Wand2 className="w-3.5 h-3.5 text-accent" />
+                      <span className="text-xs font-semibold text-foreground">
+                        Why these chords
+                      </span>
+                    </div>
+                    <ul className="space-y-1">
+                      {harmonizationExplanations.map((text, i) => (
+                        <li key={i} className="text-[11px] leading-snug text-muted">
+                          {text}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
 
                 {/* Voicing feedback removed and added to controls bar */}
 

--- a/components/creative/MelodyEditor.tsx
+++ b/components/creative/MelodyEditor.tsx
@@ -1,0 +1,454 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import clsx from "clsx";
+import { Trash2, ChevronUp, ChevronDown } from "lucide-react";
+import {
+  isWhiteKey,
+  midiToNoteName,
+  midiToPitchClass,
+  pitchClassToMidi,
+  type PitchClass,
+} from "@/lib/theory/midiUtils";
+import { spellMidiNote, spellMidiPc } from "@/lib/theory/spelling";
+import { snapMidiToScale, isScalePitchClass } from "@/lib/music/harmonizer";
+import type { MelodyNote } from "@/lib/music/generators/melody/types";
+
+/**
+ * Scale-snapped melody drawing surface — a simple DAW-style piano roll the user
+ * draws a melody into *before* any chords exist. Notes are constrained to the
+ * selected key/scale; the editor highlights scale rows and de-emphasises the
+ * rest. Tap an empty cell to add a note, drag a note to move it (pitch snaps to
+ * the scale), drag the right edge to resize, and Delete/⌫ (or the trash button)
+ * to remove the selected note. Works with mouse, pen, and touch via pointer
+ * events.
+ */
+export type MelodyEditorProps = {
+  melodyNotes: MelodyNote[];
+  /** Pitch classes of the active key/scale (notes the user may place). */
+  scalePitchClasses: PitchClass[];
+  /** Tonic of the key (highlighted distinctly). */
+  rootKey: PitchClass;
+  /** Spell labels with flats to match the active key (e.g. "Bb"). */
+  useFlats?: boolean;
+  /** Number of bars in the editable area (default 4). */
+  bars?: number;
+  /** Beats per bar (default 4). */
+  beatsPerBar?: number;
+  /** Lowest octave shown (default 4 → C4). */
+  octaveLow?: number;
+  /** Highest octave shown (default 5 → B5). */
+  octaveHigh?: number;
+  onAddNote: (note: MelodyNote) => void;
+  onMoveNote: (noteId: string, newMidi: number, newStartBeat: number) => void;
+  onResizeNote: (noteId: string, newDurationBeats: number) => void;
+  onDeleteNote: (noteId: string) => void;
+  onPlayNote?: (noteWithOctave: string) => void;
+};
+
+const ROW_HEIGHT = 16; // px per semitone row
+const QUANTIZE_BEATS = 0.25; // 1/16-note grid
+
+/** Selectable note lengths, in beats (quarter-note = 1 beat). */
+const NOTE_LENGTHS: { label: string; beats: number }[] = [
+  { label: "1/16", beats: 0.25 },
+  { label: "1/8", beats: 0.5 },
+  { label: "1/4", beats: 1 },
+  { label: "1/2", beats: 2 },
+  { label: "whole", beats: 4 },
+];
+
+let noteIdCounter = 0;
+function newNoteId(): string {
+  return `mn-draw-${++noteIdCounter}-${Date.now().toString(36)}`;
+}
+
+function quantize(value: number, step: number): number {
+  return Math.round(value / step) * step;
+}
+
+type DragState = {
+  type: "move" | "resize";
+  noteId: string;
+  startClientX: number;
+  startClientY: number;
+  origMidi: number;
+  origStartBeat: number;
+  origDuration: number;
+};
+
+export function MelodyEditor({
+  melodyNotes,
+  scalePitchClasses,
+  rootKey,
+  useFlats = false,
+  bars = 4,
+  beatsPerBar = 4,
+  octaveLow = 4,
+  octaveHigh = 5,
+  onAddNote,
+  onMoveNote,
+  onResizeNote,
+  onDeleteNote,
+  onPlayNote,
+}: MelodyEditorProps) {
+  const [noteLength, setNoteLength] = useState(1); // beats; default quarter note
+  const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
+  const dragRef = useRef<DragState | null>(null);
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  const totalBeats = bars * beatsPerBar;
+  const scaleSet = useMemo(() => new Set(scalePitchClasses), [scalePitchClasses]);
+
+  // Rows: MIDI notes from high (top) to low (bottom).
+  const rows = useMemo(() => {
+    const low = pitchClassToMidi("C", octaveLow);
+    const high = pitchClassToMidi("B", octaveHigh);
+    const arr: number[] = [];
+    for (let m = high; m >= low; m--) arr.push(m);
+    return arr;
+  }, [octaveLow, octaveHigh]);
+
+  const rowIndexOf = useCallback((midi: number) => rows.indexOf(midi), [rows]);
+  const gridHeight = rows.length * ROW_HEIGHT;
+
+  const selectedNote = useMemo(
+    () => melodyNotes.find((n) => n.id === selectedNoteId) ?? null,
+    [melodyNotes, selectedNoteId]
+  );
+
+  // ─── Coordinate helpers ───
+
+  const clientToBeat = useCallback(
+    (clientX: number): number => {
+      const rect = gridRef.current?.getBoundingClientRect();
+      if (!rect || rect.width === 0) return 0;
+      const x = clientX - rect.left;
+      const beat = (x / rect.width) * totalBeats;
+      return Math.max(0, Math.min(totalBeats, beat));
+    },
+    [totalBeats]
+  );
+
+  const clientToMidi = useCallback(
+    (clientY: number): number => {
+      const rect = gridRef.current?.getBoundingClientRect();
+      if (!rect) return rows[rows.length - 1];
+      const y = clientY - rect.top;
+      const idx = Math.max(0, Math.min(rows.length - 1, Math.floor(y / ROW_HEIGHT)));
+      return rows[idx];
+    },
+    [rows]
+  );
+
+  // ─── Add a note by tapping empty grid ───
+
+  const handleSurfacePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      // Ignore taps that land on a note bar / handle (they stopPropagation).
+      const beat = quantize(clientToBeat(e.clientX), QUANTIZE_BEATS);
+      const rawMidi = clientToMidi(e.clientY);
+      const midi = snapMidiToScale(rawMidi, scalePitchClasses);
+      const duration = noteLength;
+      const startBeat = Math.max(0, Math.min(totalBeats - QUANTIZE_BEATS, beat));
+      const noteWithOctave = midiToNoteName(midi);
+
+      const note: MelodyNote = {
+        id: newNoteId(),
+        midi,
+        noteWithOctave,
+        pitchClass: midiToPitchClass(midi),
+        durationBeats: duration,
+        startBeat,
+        chordIndex: 0,
+        isChordTone: false,
+        source: "drawn",
+      };
+      onAddNote(note);
+      setSelectedNoteId(note.id);
+      onPlayNote?.(noteWithOctave);
+    },
+    [clientToBeat, clientToMidi, scalePitchClasses, noteLength, totalBeats, onAddNote, onPlayNote]
+  );
+
+  // ─── Drag (move / resize) ───
+
+  const beginDrag = useCallback(
+    (e: React.PointerEvent, note: MelodyNote, type: "move" | "resize") => {
+      e.stopPropagation();
+      e.preventDefault();
+      setSelectedNoteId(note.id);
+      dragRef.current = {
+        type,
+        noteId: note.id,
+        startClientX: e.clientX,
+        startClientY: e.clientY,
+        origMidi: note.midi,
+        origStartBeat: note.startBeat,
+        origDuration: note.durationBeats,
+      };
+    },
+    []
+  );
+
+  useEffect(() => {
+    const handleMove = (e: PointerEvent) => {
+      const drag = dragRef.current;
+      if (!drag) return;
+      const rect = gridRef.current?.getBoundingClientRect();
+      if (!rect || rect.width === 0) return;
+
+      if (drag.type === "move") {
+        const dx = e.clientX - drag.startClientX;
+        const beatDelta = (dx / rect.width) * totalBeats;
+        const newStart = quantize(
+          Math.max(0, Math.min(totalBeats - drag.origDuration, drag.origStartBeat + beatDelta)),
+          QUANTIZE_BEATS
+        );
+        const dy = e.clientY - drag.startClientY;
+        const midiDelta = -Math.round(dy / ROW_HEIGHT);
+        const rawMidi = Math.max(rows[rows.length - 1], Math.min(rows[0], drag.origMidi + midiDelta));
+        const newMidi = snapMidiToScale(rawMidi, scalePitchClasses);
+        onMoveNote(drag.noteId, newMidi, newStart);
+      } else {
+        const dx = e.clientX - drag.startClientX;
+        const beatDelta = (dx / rect.width) * totalBeats;
+        const newDuration = quantize(
+          Math.max(QUANTIZE_BEATS, Math.min(totalBeats - drag.origStartBeat, drag.origDuration + beatDelta)),
+          QUANTIZE_BEATS
+        );
+        onResizeNote(drag.noteId, newDuration);
+      }
+    };
+    const handleUp = () => {
+      dragRef.current = null;
+    };
+    window.addEventListener("pointermove", handleMove);
+    window.addEventListener("pointerup", handleUp);
+    window.addEventListener("pointercancel", handleUp);
+    return () => {
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", handleUp);
+      window.removeEventListener("pointercancel", handleUp);
+    };
+  }, [totalBeats, rows, scalePitchClasses, onMoveNote, onResizeNote]);
+
+  // ─── Keyboard delete ───
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!selectedNoteId) return;
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === "INPUT" || tag === "SELECT" || tag === "TEXTAREA") return;
+      if (e.key === "Delete" || e.key === "Backspace") {
+        e.preventDefault();
+        onDeleteNote(selectedNoteId);
+        setSelectedNoteId(null);
+      } else if (e.key === "Escape") {
+        setSelectedNoteId(null);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [selectedNoteId, onDeleteNote]);
+
+  // ─── Step the selected note up/down within the scale (touch-friendly) ───
+
+  const stepSelected = useCallback(
+    (direction: "up" | "down") => {
+      if (!selectedNote) return;
+      const delta = direction === "up" ? 1 : -1;
+      const limitHigh = rows[0];
+      const limitLow = rows[rows.length - 1];
+      let candidate = selectedNote.midi + delta;
+      while (candidate >= limitLow && candidate <= limitHigh) {
+        if (scaleSet.has(midiToPitchClass(candidate))) {
+          onMoveNote(selectedNote.id, candidate, selectedNote.startBeat);
+          onPlayNote?.(midiToNoteName(candidate));
+          return;
+        }
+        candidate += delta;
+      }
+    },
+    [selectedNote, rows, scaleSet, onMoveNote, onPlayNote]
+  );
+
+  // Vertical grid lines (one per beat, stronger at bar boundaries).
+  const beatLines = useMemo(() => {
+    const lines: { beat: number; strong: boolean }[] = [];
+    for (let b = 0; b <= totalBeats; b += 1) {
+      lines.push({ beat: b, strong: b % beatsPerBar === 0 });
+    }
+    return lines;
+  }, [totalBeats, beatsPerBar]);
+
+  return (
+    <div className="melody-editor">
+      {/* Toolbar: note length + selected-note properties / controls */}
+      <div className="melody-editor-toolbar">
+        <div className="melody-editor-lengths" role="group" aria-label="Note length">
+          <span className="melody-editor-toolbar-label">Length</span>
+          {NOTE_LENGTHS.map((len) => (
+            <button
+              key={len.label}
+              type="button"
+              onClick={() => setNoteLength(len.beats)}
+              className={clsx(
+                "melody-editor-length-btn",
+                noteLength === len.beats && "melody-editor-length-btn-active"
+              )}
+            >
+              {len.label}
+            </button>
+          ))}
+        </div>
+
+        {selectedNote ? (
+          <div className="melody-editor-selected">
+            <span className="melody-editor-selected-info">
+              <span className="font-mono font-semibold text-foreground">
+                {spellMidiNote(selectedNote.midi, useFlats)}
+              </span>
+              <span className="text-muted">
+                · beat {(+selectedNote.startBeat.toFixed(2))} · {selectedNote.durationBeats}b
+              </span>
+            </span>
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                onClick={() => stepSelected("up")}
+                className="melody-editor-icon-btn"
+                title="Move up (in key)"
+                aria-label="Move note up"
+              >
+                <ChevronUp className="w-4 h-4" />
+              </button>
+              <button
+                type="button"
+                onClick={() => stepSelected("down")}
+                className="melody-editor-icon-btn"
+                title="Move down (in key)"
+                aria-label="Move note down"
+              >
+                <ChevronDown className="w-4 h-4" />
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  onDeleteNote(selectedNote.id);
+                  setSelectedNoteId(null);
+                }}
+                className="melody-editor-icon-btn melody-editor-delete-btn"
+                title="Delete note"
+                aria-label="Delete note"
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+        ) : (
+          <span className="melody-editor-hint-inline">Tap the grid to add a note</span>
+        )}
+      </div>
+
+      {/* Roll: pitch axis + grid */}
+      <div className="melody-editor-wrap">
+        {/* Left pitch keyboard */}
+        <div className="melody-editor-keys" style={{ height: gridHeight }}>
+          {rows.map((midi) => {
+            const pc = midiToPitchClass(midi);
+            const inScale = isScalePitchClass(pc, scalePitchClasses);
+            const isTonic = pc === rootKey;
+            return (
+              <div
+                key={midi}
+                className={clsx(
+                  "melody-editor-key",
+                  !isWhiteKey(midi) && "black",
+                  inScale && "in-scale",
+                  isTonic && "tonic"
+                )}
+                style={{ height: ROW_HEIGHT }}
+              >
+                {(inScale || pc === "C") && (
+                  <span className="melody-editor-key-label">{spellMidiPc(midi, useFlats)}</span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Grid */}
+        <div
+          ref={gridRef}
+          className="melody-editor-grid"
+          style={{ height: gridHeight }}
+        >
+          {/* Row backgrounds (scale highlight) */}
+          {rows.map((midi, idx) => {
+            const pc = midiToPitchClass(midi);
+            const inScale = isScalePitchClass(pc, scalePitchClasses);
+            const isTonic = pc === rootKey;
+            return (
+              <div
+                key={midi}
+                className={clsx(
+                  "melody-editor-row",
+                  inScale ? "in-scale" : "off-scale",
+                  isTonic && "tonic"
+                )}
+                style={{ top: idx * ROW_HEIGHT, height: ROW_HEIGHT }}
+              />
+            );
+          })}
+
+          {/* Vertical beat / bar lines */}
+          {beatLines.map(({ beat, strong }) => (
+            <div
+              key={`bl-${beat}`}
+              className={clsx("melody-editor-beat-line", strong && "strong")}
+              style={{ left: `${(beat / totalBeats) * 100}%` }}
+            />
+          ))}
+
+          {/* Tap surface for adding notes (behind the note bars) */}
+          <div
+            className="melody-editor-surface"
+            onPointerDown={handleSurfacePointerDown}
+          />
+
+          {/* Note bars */}
+          {melodyNotes.map((note) => {
+            const idx = rowIndexOf(note.midi);
+            if (idx === -1) return null; // outside the visible range
+            const leftPct = (note.startBeat / totalBeats) * 100;
+            const widthPct = (note.durationBeats / totalBeats) * 100;
+            const isSelected = note.id === selectedNoteId;
+            return (
+              <div
+                key={note.id}
+                className={clsx("melody-editor-note", isSelected && "selected")}
+                style={{
+                  left: `${leftPct}%`,
+                  width: `calc(${widthPct}% - 1px)`,
+                  top: idx * ROW_HEIGHT + 1,
+                  height: ROW_HEIGHT - 2,
+                }}
+                onPointerDown={(e) => beginDrag(e, note, "move")}
+                title={`${note.noteWithOctave} · ${note.durationBeats} beats`}
+              >
+                <span className="melody-editor-note-label">
+                  {spellMidiNote(note.midi, useFlats)}
+                </span>
+                <div
+                  className="melody-editor-resize"
+                  onPointerDown={(e) => beginDrag(e, note, "resize")}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/music/harmonizer/__tests__/harmonizeMelody.test.ts
+++ b/lib/music/harmonizer/__tests__/harmonizeMelody.test.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect } from "vitest";
+import {
+  harmonizeMelody,
+  buildDiatonicCandidates,
+  splitMelodyIntoRegions,
+  noteImportanceWeight,
+  scoreChordForRegion,
+  isScalePitchClass,
+  snapMidiToScale,
+} from "../harmonizeMelody";
+import { getScalePitchClasses } from "@/lib/state/progressionStore";
+import { getScaleDefinition } from "@/lib/theory/scale";
+import { makeSpeller } from "@/lib/theory/spelling";
+import {
+  pitchClassToMidi,
+  midiToNoteName,
+  midiToPitchClass,
+  type PitchClass,
+} from "@/lib/theory/midiUtils";
+import type { MelodyNote } from "@/lib/music/generators/melody/types";
+
+// D natural-minor scale pitch classes (sharp-canonical: A# == Bb).
+const D_MINOR_PCS = getScaleDefinition("D", "natural_minor").pitchClasses;
+
+/** Build a melody note for tests. octave-aware via pitch class + octave. */
+function note(
+  pc: PitchClass,
+  octave: number,
+  startBeat: number,
+  durationBeats: number
+): MelodyNote {
+  const midi = pitchClassToMidi(pc, octave);
+  return {
+    id: `${pc}${octave}-${startBeat}`,
+    midi,
+    noteWithOctave: midiToNoteName(midi),
+    pitchClass: pc,
+    durationBeats,
+    startBeat,
+    chordIndex: 0,
+    isChordTone: false,
+    source: "drawn",
+  };
+}
+
+describe("scale note detection", () => {
+  it("recognises the D natural-minor pitch classes", () => {
+    // D E F G A Bb(=A#) C
+    expect(D_MINOR_PCS).toEqual(["D", "E", "F", "G", "A", "A#", "C"]);
+    for (const pc of ["D", "E", "F", "G", "A", "A#", "C"] as PitchClass[]) {
+      expect(isScalePitchClass(pc, D_MINOR_PCS)).toBe(true);
+    }
+  });
+
+  it("rejects out-of-scale pitch classes", () => {
+    for (const pc of ["C#", "D#", "F#", "G#", "B"] as PitchClass[]) {
+      expect(isScalePitchClass(pc, D_MINOR_PCS)).toBe(false);
+    }
+  });
+
+  it("exposes the same scale via the store helper (aeolian → natural minor)", () => {
+    expect(getScalePitchClasses("D", "aeolian")).toEqual(D_MINOR_PCS);
+  });
+});
+
+describe("scale snapping", () => {
+  it("leaves in-scale notes untouched", () => {
+    const dMidi = pitchClassToMidi("D", 4);
+    expect(snapMidiToScale(dMidi, D_MINOR_PCS)).toBe(dMidi);
+  });
+
+  it("snaps an out-of-scale note to the nearest scale tone", () => {
+    // F# (out of D minor) should snap to F or G (one semitone away).
+    const fSharp = pitchClassToMidi("F#", 4);
+    const snapped = snapMidiToScale(fSharp, D_MINOR_PCS);
+    expect(isScalePitchClass(midiToPitchClass(snapped), D_MINOR_PCS)).toBe(true);
+    expect(Math.abs(snapped - fSharp)).toBe(1);
+  });
+
+  it("snaps C# down to C (ties prefer the lower pitch)", () => {
+    const cSharp = pitchClassToMidi("C#", 4);
+    expect(midiToPitchClass(snapMidiToScale(cSharp, D_MINOR_PCS))).toBe("C");
+  });
+});
+
+describe("diatonic chord generation (D minor)", () => {
+  const candidates = buildDiatonicCandidates("D", "natural_minor");
+
+  it("produces the seven expected D-minor triads", () => {
+    const byRoot = candidates.map((c) => ({ root: c.root, quality: c.quality }));
+    expect(byRoot).toEqual([
+      { root: "D", quality: "min" }, // i   Dm
+      { root: "E", quality: "dim" }, // ii° Edim
+      { root: "F", quality: "maj" }, // III F
+      { root: "G", quality: "min" }, // iv  Gm
+      { root: "A", quality: "min" }, // v   Am
+      { root: "A#", quality: "maj" }, // VI  Bb (A# sharp-canonical)
+      { root: "C", quality: "maj" }, // VII C
+    ]);
+  });
+
+  it("assigns correct roman numerals", () => {
+    expect(candidates.map((c) => c.romanNumeral)).toEqual([
+      "i",
+      "ii°",
+      "III",
+      "iv",
+      "v",
+      "VI",
+      "VII",
+    ]);
+  });
+
+  it("spells VI as Bb in D minor via the speller", () => {
+    const speller = makeSpeller("D", "aeolian");
+    expect(speller.symbol(candidates[5].symbol)).toBe("Bb");
+  });
+
+  it("adds seventh chords when requested", () => {
+    const withSevenths = buildDiatonicCandidates("D", "natural_minor", true);
+    expect(withSevenths).toHaveLength(14);
+    expect(withSevenths.some((c) => c.isSeventh && c.root === "D")).toBe(true);
+  });
+});
+
+describe("melody-region splitting", () => {
+  it("splits a 4-bar melody into 4 regions of 4 beats", () => {
+    const melody = [
+      note("D", 4, 0, 1),
+      note("F", 4, 4, 1),
+      note("A", 4, 8, 1),
+      note("D", 5, 12, 1),
+    ];
+    const regions = splitMelodyIntoRegions(melody, 4);
+    expect(regions).toHaveLength(4);
+    expect(regions.map((r) => r.melodyNotes.length)).toEqual([1, 1, 1, 1]);
+    expect(regions[1].startBeat).toBe(4);
+    expect(regions[1].endBeat).toBe(8);
+  });
+
+  it("always yields at least one region for an empty melody", () => {
+    expect(splitMelodyIntoRegions([], 4)).toHaveLength(1);
+  });
+
+  it("groups multiple notes within the same bar", () => {
+    const melody = [note("D", 4, 0, 1), note("F", 4, 1, 1), note("A", 4, 2, 2)];
+    const regions = splitMelodyIntoRegions(melody, 4);
+    expect(regions).toHaveLength(1);
+    expect(regions[0].melodyNotes).toHaveLength(3);
+  });
+});
+
+describe("note importance weighting", () => {
+  it("weights a long downbeat note above a short off-beat note", () => {
+    const downbeatLong = noteImportanceWeight(note("D", 4, 0, 2), 0, 4);
+    const offbeatShort = noteImportanceWeight(note("E", 4, 0.5, 0.25), 0, 4);
+    expect(downbeatLong).toBeGreaterThan(offbeatShort);
+  });
+
+  it("adds a phrase-end bonus", () => {
+    const base = noteImportanceWeight(note("A", 4, 2, 1), 0, 4);
+    const withEnd = noteImportanceWeight(note("A", 4, 2, 1), 0, 4, { isPhraseEnd: true });
+    expect(withEnd).toBeGreaterThan(base);
+  });
+});
+
+describe("chord scoring", () => {
+  it("scores the chord containing the strong-beat melody note highest", () => {
+    // A bar emphasising D, F, A — Dm should beat the C (VII) chord.
+    const region = [note("D", 4, 0, 1), note("F", 4, 1, 1), note("A", 4, 2, 2)];
+    const weighted = region.map((n) => ({
+      note: n,
+      weight: noteImportanceWeight(n, 0, 4),
+      onBeat: true,
+      isLong: n.durationBeats >= 1,
+    }));
+    const candidates = buildDiatonicCandidates("D", "natural_minor");
+    const dm = candidates[0];
+    const c = candidates[6];
+    expect(scoreChordForRegion(dm, weighted)).toBeGreaterThan(
+      scoreChordForRegion(c, weighted)
+    );
+  });
+
+  it("penalises a chord that clashes with strong melody notes", () => {
+    const region = [note("E", 4, 0, 2)]; // E on a strong, long beat
+    const weighted = region.map((n) => ({
+      note: n,
+      weight: noteImportanceWeight(n, 0, 4),
+      onBeat: true,
+      isLong: true,
+    }));
+    const candidates = buildDiatonicCandidates("D", "natural_minor");
+    const f = candidates[2]; // F major (F A C) — E clashes a semitone with F
+    const am = candidates[4]; // A minor (A C E) — contains E
+    expect(scoreChordForRegion(am, weighted)).toBeGreaterThan(
+      scoreChordForRegion(f, weighted)
+    );
+  });
+});
+
+describe("progression generation (D minor)", () => {
+  // A 4-bar melody where each bar unambiguously outlines one diatonic triad:
+  //   bar 1: D F A      → Dm  (i)
+  //   bar 2: Bb D F     → Bb  (VI)
+  //   bar 3: C E G      → C   (VII)
+  //   bar 4: D F A      → Dm  (i)
+  const melody: MelodyNote[] = [
+    note("D", 4, 0, 1),
+    note("F", 4, 1, 1),
+    note("A", 4, 2, 2),
+    note("A#", 4, 4, 2),
+    note("D", 5, 6, 1),
+    note("F", 5, 7, 1),
+    note("C", 5, 8, 2),
+    note("E", 5, 10, 1),
+    note("G", 5, 11, 1),
+    note("D", 5, 12, 2),
+    note("F", 5, 14, 1),
+    note("A", 5, 15, 1),
+  ];
+
+  it("produces a reasonable diatonic progression (Dm – Bb – C – Dm)", () => {
+    const result = harmonizeMelody({
+      melodyNotes: melody,
+      root: "D",
+      scaleType: "natural_minor",
+    });
+    expect(result.chords).toHaveLength(4);
+    expect(result.chords.map((c) => c.root)).toEqual(["D", "A#", "C", "D"]);
+    expect(result.chords.map((c) => c.quality)).toEqual(["min", "maj", "maj", "min"]);
+  });
+
+  it("spells the progression for the key when a speller is supplied", () => {
+    const result = harmonizeMelody({
+      melodyNotes: melody,
+      root: "D",
+      scaleType: "natural_minor",
+      speller: makeSpeller("D", "aeolian"),
+    });
+    expect(result.chords.map((c) => c.symbol)).toEqual(["Dm", "Bb", "C", "Dm"]);
+  });
+
+  it("keeps every generated chord diatonic to the key", () => {
+    const result = harmonizeMelody({
+      melodyNotes: melody,
+      root: "D",
+      scaleType: "natural_minor",
+    });
+    for (const chord of result.chords) {
+      for (const pc of chord.notes) {
+        expect(isScalePitchClass(pc as PitchClass, D_MINOR_PCS)).toBe(true);
+      }
+    }
+  });
+
+  it("voices each chord with playable midi notes and a full-bar duration", () => {
+    const result = harmonizeMelody({
+      melodyNotes: melody,
+      root: "D",
+      scaleType: "natural_minor",
+    });
+    for (const chord of result.chords) {
+      expect(chord.midiNotes && chord.midiNotes.length).toBeGreaterThanOrEqual(3);
+      expect(chord.notesWithOctave && chord.notesWithOctave.length).toBe(
+        chord.midiNotes!.length
+      );
+      // Ascending close voicing.
+      const m = chord.midiNotes!;
+      for (let i = 1; i < m.length; i++) expect(m[i]).toBeGreaterThan(m[i - 1]);
+      expect(chord.durationClass).toBe("full");
+    }
+  });
+
+  it("produces an explanation per chord that names the chord", () => {
+    const result = harmonizeMelody({
+      melodyNotes: melody,
+      root: "D",
+      scaleType: "natural_minor",
+      speller: makeSpeller("D", "aeolian"),
+    });
+    expect(result.explanations).toHaveLength(4);
+    expect(result.explanations[0]).toContain("Dm");
+    expect(result.explanations[0].toLowerCase()).toContain("emphasizes");
+  });
+
+  it("is deterministic — same input yields the same output", () => {
+    const opts = { melodyNotes: melody, root: "D" as PitchClass, scaleType: "natural_minor" as const };
+    const a = harmonizeMelody(opts);
+    const b = harmonizeMelody(opts);
+    expect(a.chords.map((c) => c.symbol)).toEqual(b.chords.map((c) => c.symbol));
+  });
+
+  it("opens and closes on the tonic for resolution", () => {
+    const result = harmonizeMelody({
+      melodyNotes: melody,
+      root: "D",
+      scaleType: "natural_minor",
+    });
+    expect(result.chords[0].root).toBe("D");
+    expect(result.chords[result.chords.length - 1].root).toBe("D");
+  });
+});
+
+describe("harmonization styles", () => {
+  const melody: MelodyNote[] = [
+    note("D", 4, 0, 2),
+    note("F", 4, 2, 2),
+    note("A", 4, 4, 2),
+    note("C", 5, 6, 2),
+  ];
+
+  it("supports all five styles and always returns diatonic chords", () => {
+    for (const style of ["bestFit", "darker", "brighter", "tense", "simple"] as const) {
+      const result = harmonizeMelody({
+        melodyNotes: melody,
+        root: "D",
+        scaleType: "natural_minor",
+        style,
+      });
+      expect(result.style).toBe(style);
+      expect(result.chords.length).toBeGreaterThan(0);
+      for (const chord of result.chords) {
+        for (const pc of chord.notes) {
+          expect(isScalePitchClass(pc as PitchClass, D_MINOR_PCS)).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("'simple' avoids seventh chords even when sevenths are allowed", () => {
+    const result = harmonizeMelody({
+      melodyNotes: melody,
+      root: "D",
+      scaleType: "natural_minor",
+      includeSevenths: true,
+      style: "simple",
+    });
+    expect(result.regions.every((r) => !r.candidate.isSeventh)).toBe(true);
+  });
+});

--- a/lib/music/harmonizer/harmonizeMelody.ts
+++ b/lib/music/harmonizer/harmonizeMelody.ts
@@ -1,0 +1,552 @@
+/**
+ * Rule-based melody harmonization engine.
+ *
+ * Pipeline:
+ *   1. Build the diatonic chord candidates for the key/scale.
+ *   2. Split the melody into harmonic regions (one chord per bar by default).
+ *   3. Weight each melody note's importance (strong beats, length, downbeats,
+ *      phrase ends, repetition).
+ *   4. Score every candidate against every region's weighted melody notes.
+ *   5. Choose the best progression with a Viterbi-style search that also
+ *      rewards smooth, functional chord-to-chord motion (T → PD → D → T).
+ *
+ * The whole process is deterministic — the same melody + key always yields the
+ * same progression — and every choice can be explained back to the user.
+ */
+
+import type { PitchClass } from "@/lib/theory/midiUtils";
+import { pitchClassToMidi, midiToNoteName, midiToPitchClass } from "@/lib/theory/midiUtils";
+import type { ScaleType } from "@/lib/theory/types";
+import { getScaleDefinition } from "@/lib/theory/scale";
+import {
+  buildTriadFromScale,
+  buildSeventhFromScale,
+  formatChordSymbol,
+  type TriadQuality,
+  type SeventhQuality,
+} from "@/lib/theory/chord";
+import type { Chord } from "@/lib/theory/progressionTypes";
+import type { DurationClass } from "@/lib/music/generators/advanced/types";
+import type { MelodyNote } from "@/lib/music/generators/melody/types";
+import type { Speller } from "@/lib/theory/spelling";
+import type {
+  ChordCandidate,
+  HarmonizationResult,
+  HarmonizationStyle,
+  HarmonizeOptions,
+  HarmonizedRegion,
+} from "./types";
+
+const EPSILON = 1e-6;
+const ROMAN_BASE = ["I", "II", "III", "IV", "V", "VI", "VII"];
+
+/** True when `pc` belongs to the supplied scale. */
+export function isScalePitchClass(
+  pc: PitchClass,
+  scalePitchClasses: PitchClass[]
+): boolean {
+  return scalePitchClasses.includes(pc);
+}
+
+/**
+ * Snap a MIDI note to the nearest pitch in the scale. Ties prefer the lower
+ * pitch. Used both by the drawing UI and when validating melody input.
+ */
+export function snapMidiToScale(
+  midi: number,
+  scalePitchClasses: PitchClass[]
+): number {
+  if (scalePitchClasses.length === 0) return midi;
+  const inScale = (m: number) => scalePitchClasses.includes(midiToPitchClass(m));
+  if (inScale(midi)) return midi;
+  for (let d = 1; d <= 6; d++) {
+    if (inScale(midi - d)) return midi - d;
+    if (inScale(midi + d)) return midi + d;
+  }
+  return midi;
+}
+
+/** Roman numeral for a degree, cased and decorated by triad/seventh quality. */
+function romanForDegree(
+  degreeIndex: number,
+  quality: TriadQuality | SeventhQuality
+): string {
+  const base = ROMAN_BASE[degreeIndex] ?? "I";
+  const isMinorish =
+    quality === "min" ||
+    quality === "dim" ||
+    quality === "min7" ||
+    quality === "half-dim7" ||
+    quality === "dim7";
+  let roman = isMinorish ? base.toLowerCase() : base;
+  if (quality === "dim" || quality === "dim7") roman += "°";
+  else if (quality === "half-dim7") roman += "ø";
+  else if (quality === "aug") roman += "+";
+  if (
+    quality === "maj7" ||
+    quality === "min7" ||
+    quality === "dom7" ||
+    quality === "half-dim7" ||
+    quality === "dim7"
+  ) {
+    roman += "7";
+  }
+  return roman;
+}
+
+/**
+ * Build all diatonic chord candidates for a key/scale. Triads are always
+ * produced; sevenths are added when `includeSevenths` is set.
+ */
+export function buildDiatonicCandidates(
+  root: PitchClass,
+  scaleType: ScaleType,
+  includeSevenths = false
+): ChordCandidate[] {
+  const scale = getScaleDefinition(root, scaleType);
+  const candidates: ChordCandidate[] = [];
+
+  for (let i = 0; i < 7; i++) {
+    const triad = buildTriadFromScale(scale, i);
+    candidates.push({
+      symbol: formatChordSymbol(triad.root, triad.quality),
+      root: triad.root,
+      quality: triad.quality,
+      romanNumeral: romanForDegree(i, triad.quality),
+      pitchClasses: [...triad.pitchClasses],
+      degreeIndex: i,
+      isSeventh: false,
+    });
+
+    if (includeSevenths) {
+      const seventh = buildSeventhFromScale(scale, i);
+      candidates.push({
+        symbol: formatChordSymbol(seventh.root, seventh.quality),
+        root: seventh.root,
+        quality: seventh.quality,
+        romanNumeral: romanForDegree(i, seventh.quality),
+        pitchClasses: [...seventh.pitchClasses],
+        degreeIndex: i,
+        isSeventh: true,
+      });
+    }
+  }
+
+  return candidates;
+}
+
+/** A melody note plus its computed harmonic importance for a region. */
+type WeightedNote = {
+  note: MelodyNote;
+  /** Importance weight (>= 1). Higher = matters more to the chord choice. */
+  weight: number;
+  /** Cached: does this note land on a beat (integer beat position)? */
+  onBeat: boolean;
+  /** Cached: is this a long note (>= 1 beat)? */
+  isLong: boolean;
+};
+
+function isOnBeat(startBeat: number): boolean {
+  return Math.abs(startBeat - Math.round(startBeat)) < EPSILON;
+}
+
+/**
+ * Weight a melody note by harmonic importance. Notes matter more when they fall
+ * on strong beats, are long, start a measure, end the phrase, or repeat a pitch
+ * heard often elsewhere in the melody.
+ */
+export function noteImportanceWeight(
+  note: MelodyNote,
+  regionStartBeat: number,
+  beatsPerBar: number,
+  context?: { pitchClassCounts?: Map<string, number>; isPhraseEnd?: boolean }
+): number {
+  let weight = 1;
+  const localBeat = note.startBeat - regionStartBeat;
+
+  // Strong beat (lands on a beat boundary).
+  if (isOnBeat(note.startBeat)) weight += 1;
+  // Downbeat of the bar (also "starts a measure").
+  if (Math.abs(localBeat) < EPSILON) weight += 1.5;
+  else if (Math.abs((note.startBeat % beatsPerBar)) < EPSILON) weight += 1;
+  // Longer notes anchor the harmony more.
+  if (note.durationBeats >= 1) weight += 1;
+  if (note.durationBeats >= 2) weight += 0.5;
+  // Ends a phrase (final note of the melody).
+  if (context?.isPhraseEnd) weight += 1;
+  // Repetition: pitches heard often are structurally important.
+  const count = context?.pitchClassCounts?.get(note.pitchClass) ?? 0;
+  if (count >= 3) weight += 0.5;
+
+  return weight;
+}
+
+/** Semitone distance (0-6) between two pitch classes. */
+function pcInterval(a: PitchClass, b: PitchClass): number {
+  const order = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+  const diff = Math.abs(order.indexOf(a) - order.indexOf(b)) % 12;
+  return Math.min(diff, 12 - diff);
+}
+
+/** True if `pc` sits a semitone away from any chord tone (a harsh clash). */
+function isSemitoneClash(pc: PitchClass, chordPcs: PitchClass[]): boolean {
+  if (chordPcs.includes(pc)) return false;
+  return chordPcs.some((c) => pcInterval(pc, c) === 1);
+}
+
+/**
+ * Split a melody into harmonic regions of `beatsPerBar` beats each. A note is
+ * assigned to the region its start beat falls in. There is always at least one
+ * region even for an empty melody.
+ */
+export function splitMelodyIntoRegions(
+  melodyNotes: MelodyNote[],
+  beatsPerBar: number
+): { index: number; startBeat: number; endBeat: number; melodyNotes: MelodyNote[] }[] {
+  let maxEnd = 0;
+  for (const n of melodyNotes) {
+    maxEnd = Math.max(maxEnd, n.startBeat + n.durationBeats);
+  }
+  const barCount = Math.max(1, Math.ceil((maxEnd - EPSILON) / beatsPerBar));
+
+  const regions = Array.from({ length: barCount }, (_, index) => ({
+    index,
+    startBeat: index * beatsPerBar,
+    endBeat: (index + 1) * beatsPerBar,
+    melodyNotes: [] as MelodyNote[],
+  }));
+
+  for (const note of melodyNotes) {
+    const idx = Math.min(barCount - 1, Math.floor((note.startBeat + EPSILON) / beatsPerBar));
+    regions[idx].melodyNotes.push(note);
+  }
+
+  return regions;
+}
+
+/**
+ * Score how well a chord fits a region's weighted melody notes.
+ *
+ * Chord tones on strong beats score highest; chord tones that are merely long
+ * or present still help; non-chord-tones on strong beats are penalised, and a
+ * semitone clash against an important note is penalised harder. Diatonic
+ * candidates get a small baseline bonus (every candidate here is diatonic, so
+ * this just keeps scores positive and predictable).
+ */
+export function scoreChordForRegion(
+  candidate: ChordCandidate,
+  weightedNotes: WeightedNote[]
+): number {
+  let score = 0.5; // diatonic baseline
+
+  for (const wn of weightedNotes) {
+    const { note, weight, onBeat, isLong } = wn;
+    const isChordTone = candidate.pitchClasses.includes(note.pitchClass);
+
+    if (isChordTone && onBeat) score += 3 * weight;
+    else if (isChordTone && isLong) score += 2 * weight;
+    else if (isChordTone) score += 1 * weight;
+    else if (onBeat) score -= 1 * weight;
+
+    if (!isChordTone && (onBeat || isLong) && isSemitoneClash(note.pitchClass, candidate.pitchClasses)) {
+      score -= 1.5 * weight;
+    }
+  }
+
+  // Reward a region whose downbeat note is the chord root (a clear anchor).
+  const downbeat = weightedNotes.find((wn) => isOnBeat(wn.note.startBeat));
+  if (downbeat && downbeat.note.pitchClass === candidate.root) {
+    score += 1;
+  }
+
+  return score;
+}
+
+const DOMINANT_DEGREES = new Set([4, 6]); // V / v and vii° / VII
+const PREDOMINANT_DEGREES = new Set([1, 3]); // ii / ii° and iv / IV
+
+function isDominantFn(c: ChordCandidate): boolean {
+  return DOMINANT_DEGREES.has(c.degreeIndex);
+}
+function isPredominantFn(c: ChordCandidate): boolean {
+  return PREDOMINANT_DEGREES.has(c.degreeIndex);
+}
+
+/**
+ * Score the musical motion from `prev` to `next`. Rewards functional cadences
+ * (dominant → tonic, predominant → dominant) and smooth voice leading (shared
+ * tones); discourages static repetition.
+ */
+export function scoreChordTransition(
+  prev: ChordCandidate,
+  next: ChordCandidate
+): number {
+  let s = 0;
+
+  if (isDominantFn(prev) && next.degreeIndex === 0) s += 2; // authentic cadence pull
+  if (isPredominantFn(prev) && isDominantFn(next)) s += 1; // PD → D
+  if (prev.degreeIndex === 0 && isPredominantFn(next)) s += 0.5; // T → PD
+
+  // Static repetition of the exact same chord is dull.
+  if (prev.root === next.root && prev.quality === next.quality) s -= 1;
+
+  // Smooth voice leading: shared pitch classes ease the move.
+  const shared = next.pitchClasses.filter((pc) => prev.pitchClasses.includes(pc)).length;
+  s += shared * 0.3;
+
+  return s;
+}
+
+/**
+ * Style bias applied to a candidate's emission score. Keeps `bestFit` neutral
+ * and nudges the others toward a mood. Biases are deliberately small so melody
+ * fit still dominates.
+ *
+ * TODO: these flavours are a first pass — they re-weight diatonic candidates
+ * only. Richer styles (borrowed chords, secondary dominants for "tense",
+ * modal interchange for "darker"/"brighter") can build on this hook later.
+ */
+function styleBias(candidate: ChordCandidate, style: HarmonizationStyle): number {
+  const major = candidate.quality === "maj" || candidate.quality === "maj7";
+  const minor = candidate.quality === "min" || candidate.quality === "min7";
+  const tense =
+    candidate.quality === "dim" ||
+    candidate.quality === "dim7" ||
+    candidate.quality === "half-dim7" ||
+    isDominantFn(candidate);
+
+  switch (style) {
+    case "darker":
+      return (minor ? 1.2 : 0) - (major ? 0.6 : 0);
+    case "brighter":
+      return (major ? 1.2 : 0) - (minor ? 0.6 : 0);
+    case "tense":
+      return tense ? 1.5 : 0;
+    case "simple":
+      // Prefer primary triads (I/IV/V family), avoid diminished & sevenths.
+      return (
+        ([0, 3, 4, 5].includes(candidate.degreeIndex) ? 0.8 : 0) -
+        (candidate.quality === "dim" ? 1 : 0) -
+        (candidate.isSeventh ? 1.5 : 0)
+      );
+    case "bestFit":
+    default:
+      return 0;
+  }
+}
+
+/** Voice a chord as an ascending close voicing rooted at `octave`. */
+function voicePitchClasses(pitchClasses: PitchClass[], octave: number): number[] {
+  if (pitchClasses.length === 0) return [];
+  let prev = pitchClassToMidi(pitchClasses[0], octave);
+  const midis = [prev];
+  for (let i = 1; i < pitchClasses.length; i++) {
+    let m = pitchClassToMidi(pitchClasses[i], octave);
+    while (m <= prev) m += 12;
+    midis.push(m);
+    prev = m;
+  }
+  return midis;
+}
+
+/** Turn a chosen candidate into a canonical `Chord`, spelled for the key. */
+function candidateToChord(
+  candidate: ChordCandidate,
+  octave: number,
+  durationClass: DurationClass,
+  speller?: Speller
+): Chord {
+  const midiNotes = voicePitchClasses(candidate.pitchClasses, octave);
+  const notesWithOctave = midiNotes.map((m) =>
+    speller ? speller.midiNote(m) : midiToNoteName(m)
+  );
+  const notes = candidate.pitchClasses.map((pc) => (speller ? speller.pc(pc) : pc));
+
+  return {
+    symbol: speller ? speller.symbol(candidate.symbol) : candidate.symbol,
+    notes,
+    romanNumeral: candidate.romanNumeral,
+    notesWithOctave,
+    midiNotes,
+    root: candidate.root,
+    quality: candidate.quality,
+    durationClass,
+  };
+}
+
+/** Build a plain-language explanation for why a chord was chosen for a region. */
+function explainRegion(
+  candidate: ChordCandidate,
+  weightedNotes: WeightedNote[],
+  prev: ChordCandidate | null,
+  spellPc: (pc: PitchClass) => string,
+  symbol: string
+): string {
+  // Emphasised chord tones present in the melody, ordered by importance.
+  const chordToneHits = weightedNotes
+    .filter((wn) => candidate.pitchClasses.includes(wn.note.pitchClass))
+    .sort((a, b) => b.weight - a.weight);
+
+  const seen = new Set<string>();
+  const emphasized: string[] = [];
+  for (const wn of chordToneHits) {
+    const name = spellPc(wn.note.pitchClass);
+    if (!seen.has(name)) {
+      seen.add(name);
+      emphasized.push(name);
+    }
+  }
+
+  if (emphasized.length > 0) {
+    const list =
+      emphasized.length === 1
+        ? emphasized[0]
+        : `${emphasized.slice(0, -1).join(", ")} and ${emphasized[emphasized.length - 1]}`;
+    return `${symbol} fits because your melody emphasizes ${list}.`;
+  }
+
+  // Empty / non-chord-tone bar — explain by harmonic function instead.
+  if (prev && isDominantFn(prev) && candidate.degreeIndex === 0) {
+    return `${symbol} resolves the tension back to the tonic.`;
+  }
+  if (isDominantFn(candidate)) {
+    return `${symbol} adds tension that pulls toward resolution.`;
+  }
+  if (isPredominantFn(candidate)) {
+    return `${symbol} builds motion toward the cadence.`;
+  }
+  return `${symbol} keeps the harmony moving under this bar.`;
+}
+
+/**
+ * Harmonize a melody into a deterministic, explainable chord progression.
+ */
+export function harmonizeMelody(options: HarmonizeOptions): HarmonizationResult {
+  const {
+    melodyNotes,
+    root,
+    scaleType,
+    beatsPerBar = 4,
+    octave = 3,
+    includeSevenths = false,
+    style = "bestFit",
+    speller,
+  } = options;
+
+  const spellPc = (pc: PitchClass): string => (speller ? speller.pc(pc) : pc);
+
+  // The "simple" flavour is triads-only by definition, regardless of the
+  // seventh-chord opt-in.
+  const useSevenths = includeSevenths && style !== "simple";
+  const candidates = buildDiatonicCandidates(root, scaleType, useSevenths);
+  const rawRegions = splitMelodyIntoRegions(melodyNotes, beatsPerBar);
+
+  // Context shared across regions: pitch-class frequency and the phrase-end note.
+  const pitchClassCounts = new Map<string, number>();
+  for (const n of melodyNotes) {
+    pitchClassCounts.set(n.pitchClass, (pitchClassCounts.get(n.pitchClass) ?? 0) + 1);
+  }
+  let phraseEndId: string | null = null;
+  if (melodyNotes.length > 0) {
+    phraseEndId = melodyNotes.reduce((latest, n) =>
+      n.startBeat + n.durationBeats > latest.startBeat + latest.durationBeats ? n : latest
+    ).id;
+  }
+
+  // Weight every note once, grouped by region.
+  const weightedByRegion: WeightedNote[][] = rawRegions.map((region) =>
+    region.melodyNotes.map((note) => ({
+      note,
+      weight: noteImportanceWeight(note, region.startBeat, beatsPerBar, {
+        pitchClassCounts,
+        isPhraseEnd: note.id === phraseEndId,
+      }),
+      onBeat: isOnBeat(note.startBeat),
+      isLong: note.durationBeats >= 1,
+    }))
+  );
+
+  const lastRegion = rawRegions.length - 1;
+
+  // Emission scores: candidate fit per region, plus style + positional bias.
+  const emission: number[][] = rawRegions.map((_, r) =>
+    candidates.map((c) => {
+      let e = scoreChordForRegion(c, weightedByRegion[r]) + styleBias(c, style);
+      // Open and close on the tonic for a sense of resolution.
+      if (r === 0 && c.degreeIndex === 0) e += 1;
+      if (r === lastRegion && c.degreeIndex === 0) e += 2.5;
+      return e;
+    })
+  );
+
+  // Viterbi search for the best-scoring path through the candidates.
+  const TRANSITION_WEIGHT = 1;
+  const n = candidates.length;
+  const dp: number[][] = rawRegions.map(() => new Array(n).fill(-Infinity));
+  const back: number[][] = rawRegions.map(() => new Array(n).fill(-1));
+
+  for (let c = 0; c < n; c++) dp[0][c] = emission[0][c];
+
+  for (let r = 1; r < rawRegions.length; r++) {
+    for (let c = 0; c < n; c++) {
+      let best = -Infinity;
+      let bestPrev = -1;
+      for (let p = 0; p < n; p++) {
+        const val =
+          dp[r - 1][p] + TRANSITION_WEIGHT * scoreChordTransition(candidates[p], candidates[c]);
+        if (val > best + EPSILON) {
+          best = val;
+          bestPrev = p;
+        }
+      }
+      dp[r][c] = emission[r][c] + best;
+      back[r][c] = bestPrev;
+    }
+  }
+
+  // Backtrack: pick the highest-scoring final state (first-wins tie-break keeps
+  // results deterministic and biases toward lower scale degrees / tonic).
+  let lastBest = 0;
+  for (let c = 1; c < n; c++) {
+    if (dp[lastRegion][c] > dp[lastRegion][lastBest] + EPSILON) lastBest = c;
+  }
+  const path: number[] = new Array(rawRegions.length);
+  path[lastRegion] = lastBest;
+  for (let r = lastRegion; r > 0; r--) {
+    path[r - 1] = back[r][path[r]];
+  }
+
+  // Assemble the result.
+  const regions: HarmonizedRegion[] = [];
+  const chords: Chord[] = [];
+  const explanations: string[] = [];
+  let prevCandidate: ChordCandidate | null = null;
+
+  for (let r = 0; r < rawRegions.length; r++) {
+    const candidate = candidates[path[r]];
+    const chord = candidateToChord(candidate, octave, "full", speller);
+    const explanation = explainRegion(
+      candidate,
+      weightedByRegion[r],
+      prevCandidate,
+      spellPc,
+      chord.symbol
+    );
+
+    regions.push({
+      index: r,
+      startBeat: rawRegions[r].startBeat,
+      endBeat: rawRegions[r].endBeat,
+      melodyNotes: rawRegions[r].melodyNotes,
+      candidate,
+      chord,
+      explanation,
+      score: dp[r][path[r]],
+    });
+    chords.push(chord);
+    explanations.push(explanation);
+    prevCandidate = candidate;
+  }
+
+  return { chords, regions, explanations, style };
+}

--- a/lib/music/harmonizer/index.ts
+++ b/lib/music/harmonizer/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Melody → chord harmonization engine.
+ *
+ * Public entry point: `harmonizeMelody` turns a drawn melody plus a key/scale
+ * into a deterministic, explainable diatonic chord progression.
+ */
+
+export {
+  harmonizeMelody,
+  buildDiatonicCandidates,
+  splitMelodyIntoRegions,
+  noteImportanceWeight,
+  scoreChordForRegion,
+  scoreChordTransition,
+  isScalePitchClass,
+  snapMidiToScale,
+} from "./harmonizeMelody";
+
+export type {
+  HarmonizationStyle,
+  ChordCandidate,
+  HarmonizedRegion,
+  HarmonizationResult,
+  HarmonizeOptions,
+} from "./types";

--- a/lib/music/harmonizer/types.ts
+++ b/lib/music/harmonizer/types.ts
@@ -1,0 +1,88 @@
+/**
+ * Types for the melody → chord harmonization engine.
+ *
+ * The harmonizer takes a drawn melody plus a key/scale and produces a
+ * deterministic, explainable chord progression that fits the melody. It is
+ * intentionally rule-based (no randomness, no ML) so the result is reproducible
+ * and the reasoning can be shown to the user.
+ */
+
+import type { PitchClass } from "@/lib/theory/midiUtils";
+import type { ScaleType } from "@/lib/theory/types";
+import type { TriadQuality, SeventhQuality } from "@/lib/theory/chord";
+import type { Chord } from "@/lib/theory/progressionTypes";
+import type { MelodyNote } from "@/lib/music/generators/melody/types";
+import type { Speller } from "@/lib/theory/spelling";
+
+/**
+ * The five harmonization "flavours". `bestFit` is the pure melody-fit result;
+ * the others bias chord selection toward a mood without abandoning melody fit.
+ */
+export type HarmonizationStyle =
+  | "bestFit"
+  | "darker"
+  | "brighter"
+  | "tense"
+  | "simple";
+
+/** A diatonic chord the harmonizer can choose for a region. */
+export type ChordCandidate = {
+  /** Sharp-canonical display symbol, e.g. "Dm", "A#". */
+  symbol: string;
+  /** Sharp-canonical root pitch class. */
+  root: PitchClass;
+  /** Theory quality, e.g. "min", "maj", "dim", "min7". */
+  quality: TriadQuality | SeventhQuality;
+  /** Roman numeral for the active key, e.g. "i", "ii°", "VII". */
+  romanNumeral: string;
+  /** Pitch classes that make up the chord. */
+  pitchClasses: PitchClass[];
+  /** 0-based scale degree (0 = tonic). */
+  degreeIndex: number;
+  /** Whether this candidate is a seventh chord. */
+  isSeventh: boolean;
+};
+
+/** A slice of the melody (one bar by default) and the chord chosen for it. */
+export type HarmonizedRegion = {
+  /** 0-based region/bar index. */
+  index: number;
+  startBeat: number;
+  endBeat: number;
+  melodyNotes: MelodyNote[];
+  candidate: ChordCandidate;
+  chord: Chord;
+  explanation: string;
+  score: number;
+};
+
+export type HarmonizationResult = {
+  chords: Chord[];
+  regions: HarmonizedRegion[];
+  explanations: string[];
+  style: HarmonizationStyle;
+};
+
+export type HarmonizeOptions = {
+  /** The drawn melody notes (any order). */
+  melodyNotes: MelodyNote[];
+  /** Tonic of the key, sharp-canonical (e.g. "D"). */
+  root: PitchClass;
+  /** Scale type of the key (e.g. "natural_minor"). */
+  scaleType: ScaleType;
+  /** Beats per harmonic region/bar (default 4). */
+  beatsPerBar?: number;
+  /** Octave to voice the chords in (default 3). */
+  octave?: number;
+  /** Whether to also consider diatonic seventh chords (default false). */
+  includeSevenths?: boolean;
+  /** Which harmonization flavour to produce (default "bestFit"). */
+  style?: HarmonizationStyle;
+  /**
+   * Optional enharmonic speller for the active key. When provided, chord
+   * symbols, note names, and explanations are spelled to match the key
+   * (e.g. "A#" → "Bb" in D minor). When omitted, everything stays
+   * sharp-canonical.
+   */
+  speller?: Speller;
+};

--- a/lib/state/progressionStore.ts
+++ b/lib/state/progressionStore.ts
@@ -14,6 +14,8 @@ import { getChordPitchClasses, normalizeRoot } from "../theory/chordSymbol";
 import { getScaleDefinition } from "../theory/scale";
 import type { ScaleType } from "../theory/types";
 import { makeSpeller, type Speller } from "../theory/spelling";
+import { harmonizeMelody as runHarmonization } from "../music/harmonizer";
+import type { HarmonizationStyle } from "../music/harmonizer";
 
 const MODE_TO_SCALE: Record<Mode, ScaleType> = {
     ionian: "major",
@@ -89,6 +91,8 @@ interface ProgressionState {
     melodyHarmony: MelodyHarmony;
     melodyMood: MelodyMood;
     chordsEnabled: boolean;
+    /** Per-chord explanations from the last melody harmonization, if any. */
+    harmonizationExplanations: string[];
 
     setSettings: (settings: Partial<Pick<ProgressionState, "rootKey" | "mode" | "complexity" | "numChords" | "bpm" | "voicingStyle" | "voiceCount">>) => void;
     generateNew: () => void;
@@ -118,6 +122,7 @@ interface ProgressionState {
     setMelodyHarmony: (harmony: MelodyHarmony) => void;
     setMelodyMood: (mood: MelodyMood) => void;
     generateMelodyForProgression: () => void;
+    harmonizeDrawnMelody: (style?: HarmonizationStyle) => void;
     clearMelody: () => void;
     addMelodyNote: (note: MelodyNote) => void;
     moveMelodyNote: (noteId: string, newMidi: number, newStartBeat: number) => void;
@@ -194,6 +199,7 @@ export const useProgressionStore = create<ProgressionState>((set, get) => ({
     melodyHarmony: "expressive",
     melodyMood: "emotional",
     chordsEnabled: true,
+    harmonizationExplanations: [],
 
     setSettings: (settings) => {
         set((state) => ({ ...state, ...settings }));
@@ -265,6 +271,7 @@ export const useProgressionStore = create<ProgressionState>((set, get) => ({
             substitutionTarget: null,
             substitutionOptions: [],
             melody: null,
+            harmonizationExplanations: [],
         });
         get().addToHistory(progression);
         if (get().melodyEnabled) {
@@ -391,6 +398,7 @@ export const useProgressionStore = create<ProgressionState>((set, get) => ({
             substitutionTarget: null,
             substitutionOptions: [],
             melody: null,
+            harmonizationExplanations: [],
         });
         if (get().melodyEnabled) {
             get().generateMelodyForProgression();
@@ -684,8 +692,62 @@ export const useProgressionStore = create<ProgressionState>((set, get) => ({
         set({ melody, melodyEnabled: true });
     },
 
+    /**
+     * Harmonize the currently drawn melody into a diatonic chord progression
+     * using the deterministic, rule-based harmonizer. The result replaces the
+     * current progression and the melody is re-tagged with the chord each note
+     * now sounds over (so the piano-roll overlay lines up).
+     */
+    harmonizeDrawnMelody: (style: HarmonizationStyle = "bestFit") => {
+        const { melody, rootKey, mode } = get();
+        if (!melody || melody.notes.length === 0) return;
+
+        const rootPC = (normalizeToPitchClass(rootKey) || "C") as PitchClass;
+        const scaleType = MODE_TO_SCALE[mode] ?? "major";
+        const speller = spellerFor(rootKey, mode);
+        const beatsPerBar = 4;
+
+        const result = runHarmonization({
+            melodyNotes: melody.notes,
+            root: rootPC,
+            scaleType,
+            beatsPerBar,
+            octave: 3,
+            includeSevenths: false,
+            style,
+            speller,
+        });
+
+        // Re-tag each melody note with its region's chord and chord-tone status.
+        const notes = melody.notes.map((n) => {
+            const region =
+                result.regions.find((r) => n.startBeat >= r.startBeat && n.startBeat < r.endBeat) ??
+                result.regions[result.regions.length - 1];
+            const isChordTone = region.candidate.pitchClasses.includes(n.pitchClass);
+            return { ...n, chordIndex: region.index, isChordTone };
+        });
+
+        const progression: Progression = {
+            id: `harmonized-${Date.now()}`,
+            chords: result.chords,
+            timestamp: Date.now(),
+        };
+
+        set({
+            currentProgression: progression,
+            chordSourceTypes: result.chords.map(() => "generated"),
+            originalChords: new Map(),
+            substitutionTarget: null,
+            substitutionOptions: [],
+            melody: { ...melody, notes },
+            melodyEnabled: true,
+            harmonizationExplanations: result.explanations,
+        });
+        get().addToHistory(progression);
+    },
+
     clearMelody: () => {
-        set({ melody: null, melodyEnabled: false });
+        set({ melody: null, melodyEnabled: false, harmonizationExplanations: [] });
     },
 
     addMelodyNote: (note: MelodyNote) => {


### PR DESCRIPTION
Add a "melody first, chords second" workflow: draw a melody constrained to
the selected key/scale, then generate a chord progression that harmonizes
with it.

- New deterministic, rule-based harmonizer (lib/music/harmonizer):
  builds diatonic chords for the key, splits the melody into one-bar
  regions, weights important melody notes (strong beats, long notes,
  downbeats, phrase ends, repeats), scores each diatonic chord per region,
  and chooses a progression with smooth, functional motion (T -> PD -> D
  -> T) via a Viterbi search. Returns chords + per-chord explanations.
  bestFit plus darker/brighter/tense/simple style hooks.
- New MelodyEditor component: scale-snapped piano roll. Highlights in-scale
  rows, de-emphasizes the rest, bar/beat grid, note-length selector
  (1/16-whole). Tap to add, drag to move (pitch snaps to scale), drag edge
  to resize, Delete to remove, selected-note properties, touch targets +
  resize handle + in-key steppers.
- progressionStore: harmonizeDrawnMelody action + harmonizationExplanations
  state; melody draw/move/resize/delete already supported.
- page.tsx: Draw toggle + Harmonize Melody button, editor section, "why
  these chords" explanations, and melody-only playback so a drawn melody
  loops before harmonizing and plays together with chords after.
- Tests: 26 cases covering scale detection, snapping, diatonic chord
  generation, region splitting, note importance, chord scoring, and full
  D-minor harmonization (Dm - Bb - C - Dm).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CaDChmRFifQFtiToJRRab1