### PR TITLE
Add visual MPE Expression Editor to the piano roll

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,19 @@ Rate generated voicings thumbs-up/down; ratings persist and feed an approval-tre
 
 </td>
 </tr>
+<tr>
+<td width="50%" valign="top">
+
+### 🎛️ MPE Expression Editor
+Toggle the piano roll into **MPE Editor** mode to draw expressive pitch bends right on the grid — glides, scoops, pitch drops, and vibrato. **Join** two notes (or two equal-sized chords, auto-paired voice-by-voice) into an editable bend with one click. Reshape curves like vector graphics: drag handles, insert/delete points, smooth or straighten, reverse, scale amount/duration, copy/paste. Curves stay visible in normal mode and persist independently of playback for future MPE/MIDI export.
+
+</td>
+<td width="50%" valign="top">
+
+<!-- reserved for the next feature card -->
+
+</td>
+</tr>
 </table>
 
 > Each feature is implemented in the layered architecture described below — see [Music Generation Engine](#-music-generation-engine), [Music Theory Engine](#-music-theory-engine), and [Audio Engine](#-audio-engine) for the algorithms behind them.
@@ -500,6 +513,7 @@ Harmonia/
 │   │   └── useInstrument.ts         #   Lazy load + hot-swap + fallback
 │   │
 │   ├── creative/                  # ✏️ Substitution engine + chord interpreter
+│   ├── expression/               # 🎛️ MPE expression model (types · presets · curve ops)
 │   ├── sketchpad/                 # 🧱 Song-planner store + types
 │   ├── state/                     # 🗃️ Zustand stores (progression, audio, playback)
 │   ├── favorites/ · feedback/     #   Persisted favorites & voicing feedback
@@ -507,7 +521,7 @@ Harmonia/
 │
 ├── components/                    # ⚛️ React components
 │   ├── piano-roll/ · progression/ #   Piano rolls & chord cards
-│   ├── creative/                  #   Interactive roll · substitution panel · melody lane
+│   ├── creative/                  #   Interactive roll · substitution panel · melody lane · MPE toolbar + expression overlay
 │   ├── sketchpad/                 #   Workspace · structure · section editor
 │   ├── feedback/ · audio/         #   Feedback chart · audio status badge
 │

--- a/app/globals.css
+++ b/app/globals.css
@@ -612,6 +612,103 @@
 }
 
 /* ─────────────────────────────────────────────
+   MPE EXPRESSION EDITOR CSS
+───────────────────────────────────────────── */
+
+/* Mode toggle — a compact segmented control (Piano Roll / MPE Editor). */
+.mpe-mode-switch {
+  display: inline-flex;
+  padding: 2px;
+  gap: 2px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 9px;
+  background: var(--surface-muted);
+}
+.mpe-mode-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border-radius: 7px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--muted);
+  transition: background 0.12s, color 0.12s;
+}
+.mpe-mode-btn:hover {
+  color: var(--foreground);
+}
+.mpe-mode-btn.active {
+  background: var(--surface);
+  color: var(--vert-accent-coral);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+/* Toolbar wrapper. Buttons come from Tailwind utility classes on the component;
+   this just gives the row a little breathing room and z-context for popovers. */
+.mpe-toolbar {
+  position: relative;
+  z-index: 20;
+}
+
+/* When MPE mode is active, note cells act as selection targets. */
+.roll-grid.mpe-active .note-cell.has-note {
+  cursor: pointer;
+}
+.note-cell.mpe-selected::after {
+  outline: 2px solid var(--vert-accent-teal);
+  outline-offset: 1px;
+  box-shadow: 0 0 0 2px rgba(94, 168, 160, 0.35);
+  z-index: 1;
+}
+
+/* ── Expression curve overlay ── */
+.expression-overlay {
+  overflow: visible;
+}
+.expression-overlay .expr-curve {
+  fill: none;
+  stroke: var(--vert-accent-coral);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  opacity: 0.85;
+}
+.expression-overlay .expr-curve.editable {
+  stroke-width: 2.5;
+  opacity: 1;
+  filter: drop-shadow(0 1px 2px rgba(232, 133, 106, 0.35));
+}
+.expression-overlay .expr-hit {
+  fill: none;
+  stroke: transparent;
+  stroke-width: 14;
+  cursor: copy;
+}
+.expression-overlay .expr-baseline {
+  stroke: var(--muted);
+  stroke-width: 1;
+  stroke-dasharray: 2 3;
+  opacity: 0.4;
+}
+.expression-overlay .expr-anchor {
+  fill: var(--vert-accent-coral);
+  opacity: 0.9;
+}
+.expression-overlay .expr-handle {
+  fill: #fff;
+  stroke: var(--vert-accent-coral);
+  stroke-width: 2;
+  transition: transform 0.08s;
+}
+.expression-overlay .expr-handle:hover {
+  fill: var(--vert-accent-light);
+}
+.expression-overlay .expr-handle.endpoint {
+  stroke: var(--vert-accent-teal);
+}
+
+/* ─────────────────────────────────────────────
    MELODY LANE CSS
 ───────────────────────────────────────────── */
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -111,6 +111,9 @@ export default function HarmoniaPage() {
     removeNote,
     moveNote,
     resetChord,
+    // MPE expression
+    setNoteSegments,
+    removeNoteExpression,
     // chords mute
     chordsEnabled,
     setChordsEnabled,
@@ -1402,6 +1405,8 @@ export default function HarmoniaPage() {
                     const note = melody.notes.find(n => n.id === noteId);
                     if (note) useProgressionStore.getState().moveMelodyNote(noteId, toMidi, note.startBeat);
                   } : undefined}
+                  onSetNoteSegments={setNoteSegments}
+                  onRemoveNoteExpression={removeNoteExpression}
                 />
                 <div className="lg:hidden pointer-events-none absolute right-0 top-0 bottom-0 w-5 bg-gradient-to-l from-black/10 to-transparent" />
                 </div>

--- a/components/creative/ExpressionOverlay.tsx
+++ b/components/creative/ExpressionOverlay.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+/**
+ * ExpressionOverlay — draws editable pitch-bend curves directly on top of the
+ * piano roll, aligned to the note grid.
+ *
+ * The overlay is a single absolutely-positioned SVG that scrolls with the roll
+ * content. Curves are always drawn read-only when expression exists (so the roll
+ * communicates pitch movement even in normal mode); draggable control handles
+ * appear only in MPE mode for the currently selected notes. When no expression
+ * exists the SVG renders nothing and the roll looks identical to before.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import type { Chord } from "@/lib/theory/progressionTypes";
+import type { ExpressionSegment } from "@/lib/expression/types";
+import { buildSvgPath, clamp, insertPointAt, removePointAt, sortPoints, type PixelPoint } from "@/lib/expression/curve";
+
+export interface ColumnGeom {
+  left: number;
+  width: number;
+}
+
+export interface RollGeom {
+  columns: ColumnGeom[];
+  cellsTop: number;
+  rowHeight: number;
+  contentWidth: number;
+  contentHeight: number;
+}
+
+export interface SelectedNoteRef {
+  chordIndex: number;
+  midi: number;
+}
+
+interface ExpressionOverlayProps {
+  chords: Chord[];
+  noteRange: number[];
+  geom: RollGeom | null;
+  mpeMode: boolean;
+  /** Notes whose control handles should be shown/editable. */
+  selection: SelectedNoteRef[];
+  /** Scroll container used to convert client coords → content coords during drag. */
+  containerRef: React.RefObject<HTMLDivElement>;
+  onUpdateSegment: (
+    chordIndex: number,
+    midi: number,
+    segId: string,
+    patch: Partial<Pick<ExpressionSegment, "points" | "smooth">>
+  ) => void;
+}
+
+interface DragState {
+  chordIndex: number;
+  midi: number;
+  segId: string;
+  pointIndex: number;
+  isEndpoint: boolean;
+}
+
+/** A curve resolved to pixel space for one segment of one note. */
+interface ResolvedCurve {
+  chordIndex: number;
+  midi: number;
+  seg: ExpressionSegment;
+  pixels: PixelPoint[];
+  centerY: number;
+  colLeft: number;
+  colWidth: number;
+}
+
+const SEMI_LIMIT = 24; // clamp handle drags to ±2 octaves
+
+export function ExpressionOverlay({
+  chords,
+  noteRange,
+  geom,
+  mpeMode,
+  selection,
+  containerRef,
+  onUpdateSegment,
+}: ExpressionOverlayProps) {
+  const [drag, setDrag] = useState<DragState | null>(null);
+  const dragRef = useRef<DragState | null>(null);
+  dragRef.current = drag;
+
+  const selectedKey = useCallback(
+    (chordIndex: number, midi: number) =>
+      selection.some((s) => s.chordIndex === chordIndex && s.midi === midi),
+    [selection]
+  );
+
+  // Resolve every stored segment into pixel space. Segments whose note no longer
+  // exists in the chord are skipped, so stale keys never draw.
+  const curves: ResolvedCurve[] = [];
+  if (geom) {
+    chords.forEach((chord, chordIndex) => {
+      const expr = chord.expressions;
+      const col = geom.columns[chordIndex];
+      if (!expr || !col) return;
+      const midiSet = new Set(chord.midiNotes ?? []);
+      for (const midiKey of Object.keys(expr)) {
+        const midi = Number(midiKey);
+        if (!midiSet.has(midi)) continue;
+        const rowIndex = noteRange.indexOf(midi);
+        if (rowIndex === -1) continue;
+        const centerY = geom.cellsTop + rowIndex * geom.rowHeight + geom.rowHeight / 2;
+        for (const seg of expr[midi]) {
+          const pts = sortPoints(seg.points);
+          const pixels = pts.map((p) => ({
+            x: col.left + p.t * col.width,
+            y: centerY - p.y * geom.rowHeight,
+          }));
+          curves.push({ chordIndex, midi, seg, pixels, centerY, colLeft: col.left, colWidth: col.width });
+        }
+      }
+    });
+  }
+
+  // ─── Drag handling ───
+
+  const clientToLocal = useCallback(
+    (clientX: number, clientY: number) => {
+      const container = containerRef.current;
+      if (!container) return null;
+      const rect = container.getBoundingClientRect();
+      return {
+        x: clientX - rect.left + container.scrollLeft,
+        y: clientY - rect.top + container.scrollTop,
+      };
+    },
+    [containerRef]
+  );
+
+  useEffect(() => {
+    if (!drag || !geom) return;
+
+    const handleMove = (e: PointerEvent) => {
+      const d = dragRef.current;
+      if (!d) return;
+      const local = clientToLocal(e.clientX, e.clientY);
+      if (!local) return;
+      const col = geom.columns[d.chordIndex];
+      if (!col) return;
+
+      const chord = chords[d.chordIndex];
+      const seg = chord.expressions?.[d.midi]?.find((s) => s.id === d.segId);
+      if (!seg) return;
+
+      const rowIndex = noteRange.indexOf(d.midi);
+      const centerY = geom.cellsTop + rowIndex * geom.rowHeight + geom.rowHeight / 2;
+
+      const points = sortPoints(seg.points);
+      const newY = clamp((centerY - local.y) / geom.rowHeight, -SEMI_LIMIT, SEMI_LIMIT);
+      let newT = clamp((local.x - col.left) / Math.max(col.width, 1), 0, 1);
+
+      const next = points.map((p, i) => {
+        if (i !== d.pointIndex) return p;
+        // Endpoints keep their t pinned to 0 / 1; only their pitch moves. Middle
+        // points move freely but stay ordered between their neighbours.
+        if (d.isEndpoint) {
+          return { t: p.t, y: newY };
+        }
+        const lo = points[i - 1] ? points[i - 1].t + 0.001 : 0;
+        const hi = points[i + 1] ? points[i + 1].t - 0.001 : 1;
+        newT = clamp(newT, lo, hi);
+        return { t: newT, y: newY };
+      });
+
+      onUpdateSegment(d.chordIndex, d.midi, d.segId, { points: sortPoints(next) });
+    };
+
+    const handleUp = () => setDrag(null);
+
+    window.addEventListener("pointermove", handleMove);
+    window.addEventListener("pointerup", handleUp);
+    window.addEventListener("pointercancel", handleUp);
+    return () => {
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", handleUp);
+      window.removeEventListener("pointercancel", handleUp);
+    };
+  }, [drag, geom, chords, noteRange, clientToLocal, onUpdateSegment]);
+
+  const startDrag = useCallback(
+    (e: React.PointerEvent, c: ResolvedCurve, pointIndex: number) => {
+      if (!mpeMode) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const isEndpoint = pointIndex === 0 || pointIndex === c.pixels.length - 1;
+      setDrag({ chordIndex: c.chordIndex, midi: c.midi, segId: c.seg.id, pointIndex, isEndpoint });
+    },
+    [mpeMode]
+  );
+
+  // Double-click a handle to delete it (endpoints are protected inside removePointAt).
+  const deletePoint = useCallback(
+    (c: ResolvedCurve, pointIndex: number) => {
+      if (!mpeMode) return;
+      const next = removePointAt(sortPoints(c.seg.points), pointIndex);
+      onUpdateSegment(c.chordIndex, c.midi, c.seg.id, { points: next });
+    },
+    [mpeMode, onUpdateSegment]
+  );
+
+  // Double-click the curve line to insert a control point where you clicked.
+  const insertPoint = useCallback(
+    (e: React.MouseEvent, c: ResolvedCurve) => {
+      if (!mpeMode) return;
+      e.stopPropagation();
+      const local = clientToLocal(e.clientX, e.clientY);
+      if (!local) return;
+      const t = clamp((local.x - c.colLeft) / Math.max(c.colWidth, 1), 0, 1);
+      const next = insertPointAt(sortPoints(c.seg.points), t);
+      onUpdateSegment(c.chordIndex, c.midi, c.seg.id, { points: next });
+    },
+    [mpeMode, clientToLocal, onUpdateSegment]
+  );
+
+  if (!geom) return null;
+
+  return (
+    <svg
+      className="expression-overlay"
+      width={geom.contentWidth}
+      height={geom.contentHeight}
+      style={{ position: "absolute", left: 0, top: 0, pointerEvents: "none", zIndex: 6 }}
+    >
+      {curves.map((c) => {
+        const editable = mpeMode && selectedKey(c.chordIndex, c.midi);
+        const path = buildSvgPath(c.pixels, c.seg.smooth);
+        const startPx = c.pixels[0];
+        const endPx = c.pixels[c.pixels.length - 1];
+        return (
+          <g key={`${c.chordIndex}-${c.midi}-${c.seg.id}`}>
+            {/* Base pitch guide (thin dotted line at the note's centre) */}
+            {editable && (
+              <line
+                x1={c.colLeft}
+                y1={c.centerY}
+                x2={c.colLeft + c.colWidth}
+                y2={c.centerY}
+                className="expr-baseline"
+              />
+            )}
+
+            {/* Wide invisible hit-path for inserting points (MPE only) */}
+            {editable && (
+              <path
+                d={path}
+                className="expr-hit"
+                style={{ pointerEvents: "stroke" }}
+                onDoubleClick={(e) => insertPoint(e, c)}
+              />
+            )}
+
+            {/* The visible curve */}
+            <path d={path} className={editable ? "expr-curve editable" : "expr-curve"} />
+
+            {/* Start/end anchor dots (always visible so the gesture reads clearly) */}
+            <circle cx={startPx.x} cy={startPx.y} r={editable ? 3 : 2} className="expr-anchor" />
+            <circle cx={endPx.x} cy={endPx.y} r={editable ? 3 : 2} className="expr-anchor" />
+
+            {/* Draggable handles (MPE + selected only) */}
+            {editable &&
+              c.pixels.map((px, i) => (
+                <circle
+                  key={i}
+                  cx={px.x}
+                  cy={px.y}
+                  r={5.5}
+                  className={
+                    i === 0 || i === c.pixels.length - 1
+                      ? "expr-handle endpoint"
+                      : "expr-handle"
+                  }
+                  style={{ pointerEvents: "all", cursor: "grab" }}
+                  onPointerDown={(e) => startDrag(e, c, i)}
+                  onDoubleClick={(e) => {
+                    e.stopPropagation();
+                    deletePoint(c, i);
+                  }}
+                />
+              ))}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/components/creative/InteractivePianoRoll.tsx
+++ b/components/creative/InteractivePianoRoll.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import React, { useMemo, useState, useCallback, useRef, useEffect } from "react";
+import React, { useMemo, useState, useCallback, useRef, useEffect, useLayoutEffect } from "react";
 import clsx from "clsx";
-import { Download, RotateCcw, ChevronUp, ChevronDown } from "lucide-react";
+import { Download, RotateCcw, ChevronUp, ChevronDown, SlidersHorizontal, Music } from "lucide-react";
 import {
   isWhiteKey,
   midiToNoteName,
@@ -15,6 +15,27 @@ import { Heart } from "lucide-react";
 import type { Chord } from "@/lib/theory/progressionTypes";
 import type { ChordSourceType } from "@/lib/creative/types";
 import type { MelodyNote } from "@/lib/music/generators/melody/types";
+import type { ExpressionSegment } from "@/lib/expression/types";
+import {
+  makeSegmentId,
+  reversePoints,
+  scaleAmount as scaleAmountPoints,
+  scaleDuration as scaleDurationPoints,
+} from "@/lib/expression/curve";
+import {
+  glideCurve,
+  pitchDropCurve,
+  pitchScoopCurve,
+  vibratoCurve,
+  toSegment,
+  DEFAULT_GLIDE_TARGET,
+  type GlidePreset,
+  type PitchDropOptions,
+  type PitchScoopOptions,
+  type VibratoOptions,
+} from "@/lib/expression/presets";
+import { MpeToolbar, type MpeSelectionKind } from "./MpeToolbar";
+import { ExpressionOverlay, type RollGeom, type SelectedNoteRef } from "./ExpressionOverlay";
 
 export type InteractivePianoRollProps = {
   chords: Chord[];
@@ -38,6 +59,11 @@ export type InteractivePianoRollProps = {
   melodyNotes?: MelodyNote[];
   showMelody?: boolean;
   onMoveMelodyNote?: (noteId: string, toMidi: number) => void;
+  // ─── MPE expression editing ───
+  // When these are provided the "MPE Editor" mode toggle appears. Absent them,
+  // the roll behaves exactly as before.
+  onSetNoteSegments?: (chordIndex: number, midi: number, segments: ExpressionSegment[]) => void;
+  onRemoveNoteExpression?: (chordIndex: number, midi: number) => void;
 };
 
 /** Compute the MIDI range needed to display all chord notes, with padding. */
@@ -127,6 +153,8 @@ export function InteractivePianoRoll({
   melodyNotes,
   showMelody,
   onMoveMelodyNote,
+  onSetNoteSegments,
+  onRemoveNoteExpression,
 }: InteractivePianoRollProps) {
   const [hoveredColumnIdx, setHoveredColumnIdx] = useState<number | null>(null);
   const [selectedNote, setSelectedNote] = useState<SelectedNote | null>(null);
@@ -134,6 +162,15 @@ export function InteractivePianoRoll({
   const [isDragging, setIsDragging] = useState(false);
   const [dragStart, setDragStart] = useState<{ chordIndex: number; midi: number } | null>(null);
   const [draggingMelodyId, setDraggingMelodyId] = useState<string | null>(null);
+
+  // ─── MPE Editor state ───
+  const mpeAvailable = !!onSetNoteSegments;
+  const [mpeMode, setMpeMode] = useState(false);
+  const [mpeSelection, setMpeSelection] = useState<SelectedNoteRef[]>([]);
+  const [clipboard, setClipboard] = useState<ExpressionSegment[] | null>(null);
+  const [geom, setGeom] = useState<RollGeom | null>(null);
+  const gridRef = useRef<HTMLDivElement>(null);
+  const cellsRefs = useRef<(HTMLDivElement | null)[]>([]);
 
   useEffect(() => {
     if (selectedIndex === null) {
@@ -254,6 +291,8 @@ export function InteractivePianoRoll({
   // the up/down steppers instead, which keep notes in the scale).
   const handlePointerDown = useCallback((e: React.PointerEvent, midi: number, colIdx: number, hasNote: boolean) => {
     if (e.pointerType === "touch") return;
+    // In MPE mode a drag on a note edits its expression curve, not its pitch.
+    if (mpeMode) return;
     if (hasNote && onMoveNote) {
       if (e.currentTarget.hasPointerCapture?.(e.pointerId)) {
         e.currentTarget.releasePointerCapture(e.pointerId);
@@ -261,7 +300,7 @@ export function InteractivePianoRoll({
       setIsDragging(true);
       setDragStart({ chordIndex: colIdx, midi });
     }
-  }, [onMoveNote]);
+  }, [onMoveNote, mpeMode]);
 
   const handlePointerEnterCell = useCallback((midi: number, colIdx: number) => {
     if (isDragging && dragStart && dragStart.chordIndex === colIdx && dragStart.midi !== midi) {
@@ -380,11 +419,354 @@ export function InteractivePianoRoll({
     return spellMidiNote(selectedNote.midi, useFlats);
   }, [selectedNote, useFlats]);
 
+  // ─── MPE geometry measurement ───
+  // The expression overlay draws on an SVG aligned to the note grid. Column
+  // widths flex with chord duration and available width, so we measure the DOM
+  // rather than compute — cheap and robust across responsive layouts.
+  const measureGeom = useCallback(() => {
+    const grid = gridRef.current;
+    if (!grid) return;
+    const gridRect = grid.getBoundingClientRect();
+    const columns: { left: number; width: number }[] = [];
+    let rowHeight = 0;
+    let cellsTop = 0;
+    for (let i = 0; i < chords.length; i++) {
+      const el = cellsRefs.current[i];
+      if (!el) {
+        columns.push({ left: 0, width: 0 });
+        continue;
+      }
+      const r = el.getBoundingClientRect();
+      const left = r.left - gridRect.left + grid.scrollLeft;
+      const top = r.top - gridRect.top + grid.scrollTop;
+      columns.push({ left, width: r.width });
+      if (i === 0) {
+        cellsTop = top;
+        rowHeight = r.height / Math.max(noteRange.length, 1);
+      }
+    }
+    setGeom({
+      columns,
+      cellsTop,
+      rowHeight,
+      contentWidth: grid.scrollWidth,
+      contentHeight: grid.scrollHeight,
+    });
+  }, [chords.length, noteRange.length]);
+
+  useLayoutEffect(() => {
+    measureGeom();
+  }, [measureGeom, chords, autoRange, mpeMode, showMelody, melodyNotes]);
+
+  useEffect(() => {
+    const grid = gridRef.current;
+    if (!grid) return;
+    const ro = new ResizeObserver(() => measureGeom());
+    ro.observe(grid);
+    window.addEventListener("resize", measureGeom);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener("resize", measureGeom);
+    };
+  }, [measureGeom]);
+
+  // Reset MPE selection whenever mode turns off.
+  useEffect(() => {
+    if (!mpeMode) setMpeSelection([]);
+  }, [mpeMode]);
+
+  // ─── MPE selection helpers ───
+
+  const isMpeSelected = useCallback(
+    (chordIndex: number, midi: number) =>
+      mpeSelection.some((s) => s.chordIndex === chordIndex && s.midi === midi),
+    [mpeSelection]
+  );
+
+  const toggleMpeNote = useCallback((chordIndex: number, midi: number) => {
+    setMpeSelection((sel) => {
+      const exists = sel.some((s) => s.chordIndex === chordIndex && s.midi === midi);
+      return exists
+        ? sel.filter((s) => !(s.chordIndex === chordIndex && s.midi === midi))
+        : [...sel, { chordIndex, midi }];
+    });
+  }, []);
+
+  const toggleMpeChord = useCallback((chordIndex: number) => {
+    const midis = chords[chordIndex]?.midiNotes ?? [];
+    if (midis.length === 0) return;
+    setMpeSelection((sel) => {
+      const allSelected = midis.every((m) => sel.some((s) => s.chordIndex === chordIndex && s.midi === m));
+      if (allSelected) {
+        return sel.filter((s) => s.chordIndex !== chordIndex);
+      }
+      const withoutChord = sel.filter((s) => s.chordIndex !== chordIndex);
+      return [...withoutChord, ...midis.map((m) => ({ chordIndex, midi: m }))];
+    });
+  }, [chords]);
+
+  // Classify the selection so the toolbar can offer the right operations.
+  const { selectionKind, selectionCount } = useMemo<{ selectionKind: MpeSelectionKind; selectionCount: number }>(() => {
+    const count = mpeSelection.length;
+    if (count === 0) return { selectionKind: "none", selectionCount: 0 };
+    if (count === 2) return { selectionKind: "two-notes", selectionCount: 2 };
+
+    const byChord = new Map<number, number[]>();
+    for (const s of mpeSelection) {
+      const list = byChord.get(s.chordIndex) ?? [];
+      list.push(s.midi);
+      byChord.set(s.chordIndex, list);
+    }
+    const chordIndices = Array.from(byChord.keys());
+
+    if (chordIndices.length === 2) {
+      const bothFull = chordIndices.every((ci) => {
+        const total = chords[ci]?.midiNotes?.length ?? 0;
+        return total > 0 && byChord.get(ci)!.length === total;
+      });
+      if (bothFull) {
+        const sizeA = chords[chordIndices[0]]!.midiNotes!.length;
+        const sizeB = chords[chordIndices[1]]!.midiNotes!.length;
+        return {
+          selectionKind: sizeA === sizeB ? "two-chords" : "two-chords-unequal",
+          selectionCount: count,
+        };
+      }
+    }
+    if (count === 1) return { selectionKind: "one-note", selectionCount: 1 };
+    return { selectionKind: "multi-notes", selectionCount: count };
+  }, [mpeSelection, chords]);
+
+  const segmentsFor = useCallback(
+    (chordIndex: number, midi: number): ExpressionSegment[] =>
+      chords[chordIndex]?.expressions?.[midi] ?? [],
+    [chords]
+  );
+
+  const hasExpression = useMemo(
+    () => mpeSelection.some((s) => segmentsFor(s.chordIndex, s.midi).length > 0),
+    [mpeSelection, segmentsFor]
+  );
+
+  // ─── MPE operations ───
+
+  // Update a single segment in place (used by the overlay's drag/insert/delete).
+  const handleUpdateSegment = useCallback(
+    (
+      chordIndex: number,
+      midi: number,
+      segId: string,
+      patch: Partial<Pick<ExpressionSegment, "points" | "smooth">>
+    ) => {
+      if (!onSetNoteSegments) return;
+      const current = segmentsFor(chordIndex, midi);
+      const next = current.map((s) => (s.id === segId ? { ...s, ...patch } : s));
+      onSetNoteSegments(chordIndex, midi, next);
+    },
+    [onSetNoteSegments, segmentsFor]
+  );
+
+  // Apply a freshly-built single segment to every selected note (replacing any
+  // existing expression on that note — v1 keeps one authored segment per note).
+  const applySegmentToSelection = useCallback(
+    (build: (chordIndex: number, midi: number) => ExpressionSegment | null) => {
+      if (!onSetNoteSegments) return;
+      for (const s of mpeSelection) {
+        const seg = build(s.chordIndex, s.midi);
+        if (seg) onSetNoteSegments(s.chordIndex, s.midi, [seg]);
+      }
+    },
+    [onSetNoteSegments, mpeSelection]
+  );
+
+  const handleGlide = useCallback(
+    (preset: GlidePreset) => {
+      applySegmentToSelection((ci, midi) => {
+        const existing = segmentsFor(ci, midi)[0];
+        // Reshape an existing glide (keep its target pitch) or start a fresh one.
+        const target = existing
+          ? existing.points[existing.points.length - 1].y || DEFAULT_GLIDE_TARGET
+          : DEFAULT_GLIDE_TARGET;
+        return toSegment("glide", glideCurve(preset, target));
+      });
+    },
+    [applySegmentToSelection, segmentsFor]
+  );
+
+  const handlePitchDrop = useCallback(
+    (opts: PitchDropOptions) => applySegmentToSelection(() => toSegment("drop", pitchDropCurve(opts))),
+    [applySegmentToSelection]
+  );
+  const handleScoop = useCallback(
+    (opts: PitchScoopOptions) => applySegmentToSelection(() => toSegment("scoop", pitchScoopCurve(opts))),
+    [applySegmentToSelection]
+  );
+  const handleVibrato = useCallback(
+    (opts: VibratoOptions) => applySegmentToSelection(() => toSegment("vibrato", vibratoCurve(opts))),
+    [applySegmentToSelection]
+  );
+
+  // Join: create a linear pitch bend from a source note up/down to a target
+  // note's pitch. For two chords of equal size, pair notes by pitch order and
+  // give each pair its own independent bend.
+  const handleJoin = useCallback(() => {
+    if (!onSetNoteSegments) return;
+    const buildBend = (srcChord: number, srcMidi: number, tgtMidi: number) => {
+      const target = tgtMidi - srcMidi;
+      onSetNoteSegments(srcChord, srcMidi, [toSegment("glide", glideCurve("join", target))]);
+    };
+
+    if (selectionKind === "two-notes") {
+      const sorted = [...mpeSelection].sort(
+        (a, b) => a.chordIndex - b.chordIndex || a.midi - b.midi
+      );
+      const [src, tgt] = sorted;
+      buildBend(src.chordIndex, src.midi, tgt.midi);
+    } else if (selectionKind === "two-chords") {
+      const byChord = new Map<number, number[]>();
+      for (const s of mpeSelection) {
+        const list = byChord.get(s.chordIndex) ?? [];
+        list.push(s.midi);
+        byChord.set(s.chordIndex, list);
+      }
+      const [ciA, ciB] = Array.from(byChord.keys()).sort((a, b) => a - b);
+      const notesA = byChord.get(ciA)!.sort((a, b) => a - b);
+      const notesB = byChord.get(ciB)!.sort((a, b) => a - b);
+      for (let i = 0; i < notesA.length; i++) {
+        buildBend(ciA, notesA[i], notesB[i]);
+      }
+    }
+  }, [onSetNoteSegments, selectionKind, mpeSelection]);
+
+  const handleReset = useCallback(() => {
+    if (!onRemoveNoteExpression) return;
+    for (const s of mpeSelection) onRemoveNoteExpression(s.chordIndex, s.midi);
+  }, [onRemoveNoteExpression, mpeSelection]);
+
+  const handleReverse = useCallback(() => {
+    if (!onSetNoteSegments) return;
+    for (const s of mpeSelection) {
+      const segs = segmentsFor(s.chordIndex, s.midi);
+      if (segs.length === 0) continue;
+      onSetNoteSegments(
+        s.chordIndex,
+        s.midi,
+        segs.map((seg) => ({ ...seg, points: reversePoints(seg.points) }))
+      );
+    }
+  }, [onSetNoteSegments, mpeSelection, segmentsFor]);
+
+  const handleScaleAmount = useCallback(
+    (factor: number) => {
+      if (!onSetNoteSegments) return;
+      for (const s of mpeSelection) {
+        const segs = segmentsFor(s.chordIndex, s.midi);
+        if (segs.length === 0) continue;
+        onSetNoteSegments(
+          s.chordIndex,
+          s.midi,
+          segs.map((seg) => ({ ...seg, points: scaleAmountPoints(seg.points, factor) }))
+        );
+      }
+    },
+    [onSetNoteSegments, mpeSelection, segmentsFor]
+  );
+
+  const handleScaleDuration = useCallback(
+    (factor: number) => {
+      if (!onSetNoteSegments) return;
+      for (const s of mpeSelection) {
+        const segs = segmentsFor(s.chordIndex, s.midi);
+        if (segs.length === 0) continue;
+        onSetNoteSegments(
+          s.chordIndex,
+          s.midi,
+          segs.map((seg) => ({ ...seg, points: scaleDurationPoints(seg.points, factor) }))
+        );
+      }
+    },
+    [onSetNoteSegments, mpeSelection, segmentsFor]
+  );
+
+  // Clone segments with fresh ids so pasted/duplicated copies are independent.
+  const cloneSegments = (segs: ExpressionSegment[]): ExpressionSegment[] =>
+    segs.map((seg) => ({ ...seg, id: makeSegmentId(), points: seg.points.map((p) => ({ ...p })) }));
+
+  const handleCopy = useCallback(() => {
+    const withExpr = mpeSelection.find((s) => segmentsFor(s.chordIndex, s.midi).length > 0);
+    if (withExpr) setClipboard(cloneSegments(segmentsFor(withExpr.chordIndex, withExpr.midi)));
+  }, [mpeSelection, segmentsFor]);
+
+  const handlePaste = useCallback(() => {
+    if (!onSetNoteSegments || !clipboard) return;
+    for (const s of mpeSelection) onSetNoteSegments(s.chordIndex, s.midi, cloneSegments(clipboard));
+  }, [onSetNoteSegments, clipboard, mpeSelection]);
+
+  const handleDuplicate = useCallback(() => {
+    if (!onSetNoteSegments) return;
+    const source = mpeSelection.find((s) => segmentsFor(s.chordIndex, s.midi).length > 0);
+    if (!source) return;
+    const segs = segmentsFor(source.chordIndex, source.midi);
+    for (const s of mpeSelection) {
+      if (s.chordIndex === source.chordIndex && s.midi === source.midi) continue;
+      onSetNoteSegments(s.chordIndex, s.midi, cloneSegments(segs));
+    }
+  }, [onSetNoteSegments, mpeSelection, segmentsFor]);
+
   return (
     <div className="piano-roll-section">
+      {/* Mode toggle — reveals the MPE expression tools without leaving the
+          piano roll. The roll stays fully visible in both modes. */}
+      {mpeAvailable && (
+        <div className="flex items-center justify-between gap-2 mb-2">
+          <div className="mpe-mode-switch">
+            <button
+              type="button"
+              onClick={() => setMpeMode(false)}
+              className={clsx("mpe-mode-btn", !mpeMode && "active")}
+              aria-pressed={!mpeMode}
+            >
+              <Music className="w-3.5 h-3.5" />
+              <span>Piano Roll</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => setMpeMode(true)}
+              className={clsx("mpe-mode-btn", mpeMode && "active")}
+              aria-pressed={mpeMode}
+            >
+              <SlidersHorizontal className="w-3.5 h-3.5" />
+              <span>MPE Editor</span>
+            </button>
+          </div>
+        </div>
+      )}
+
+      {mpeMode && mpeAvailable && (
+        <MpeToolbar
+          selectionKind={selectionKind}
+          selectionCount={selectionCount}
+          hasExpression={hasExpression}
+          canPaste={clipboard !== null}
+          onGlide={handleGlide}
+          onPitchDrop={handlePitchDrop}
+          onScoop={handleScoop}
+          onVibrato={handleVibrato}
+          onJoin={handleJoin}
+          onReset={handleReset}
+          onReverse={handleReverse}
+          onScaleAmount={handleScaleAmount}
+          onScaleDuration={handleScaleDuration}
+          onCopy={handleCopy}
+          onPaste={handlePaste}
+          onDuplicate={handleDuplicate}
+          onRemove={handleReset}
+        />
+      )}
+
       {/* Selected-note stepper: tap a note, then nudge it up/down within the
           key. The primary editing control on touch (where drag is disabled). */}
-      {selectedNote && (
+      {!mpeMode && selectedNote && (
         <div className="flex items-center justify-center gap-2 mb-2">
           <span className="text-[11px] text-muted">
             Note <span className="font-semibold text-foreground font-mono">{selectedNoteLabel}</span>
@@ -442,7 +824,7 @@ export function InteractivePianoRoll({
         </div>
 
         {/* RIGHT NOTE GRID */}
-        <div className="roll-grid">
+        <div className={clsx("roll-grid", mpeMode && "mpe-active")} ref={gridRef}>
           {chords.map((chord, colIdx) => {
             const isPlaying = playingIndex === colIdx;
             const isSelected = selectedIndex === colIdx;
@@ -464,6 +846,10 @@ export function InteractivePianoRoll({
                 <div
                   className={clsx("roll-col-header", isSelected && "selected-header")}
                   onClick={() => {
+                    if (mpeMode) {
+                      toggleMpeChord(colIdx);
+                      return;
+                    }
                     onSelectChord?.(isSelected ? null : colIdx);
                     setSelectedNote(null);
                   }}
@@ -487,7 +873,7 @@ export function InteractivePianoRoll({
                   </div>
                 </div>
 
-                <div className="roll-col-cells">
+                <div className="roll-col-cells" ref={(el) => { cellsRefs.current[colIdx] = el; }}>
                   {noteRange.map((midi) => {
                     const isWhite = isWhiteKey(midi);
                     const pClass = midiToPitchClass(midi);
@@ -498,6 +884,7 @@ export function InteractivePianoRoll({
                     const isFlashing = flashingNote === midi && hoveredColumnIdx === colIdx;
                     const isNoteSelected = selectedNote?.chordIndex === colIdx && selectedNote?.midi === midi;
                     const isDragTarget = isDragging && dragStart?.chordIndex === colIdx;
+                    const isMpeSel = mpeMode && hasNote && isMpeSelected(colIdx, midi);
 
                     return (
                       <div
@@ -509,11 +896,27 @@ export function InteractivePianoRoll({
                           isRoot && "is-root",
                           isFlashing && "triggered",
                           isNoteSelected && "note-selected",
+                          isMpeSel && "mpe-selected",
                           isDragTarget && "cursor-ns-resize",
-                          !hasNote && isSelected && "hover:ring-1 hover:ring-accent/20 hover:bg-accent/5"
+                          !hasNote && isSelected && !mpeMode && "hover:ring-1 hover:ring-accent/20 hover:bg-accent/5"
                         )}
                         data-note={pClass}
-                        onClick={() => handleNoteClick(midi, colIdx, hasNote)}
+                        onClick={() => {
+                          if (mpeMode) {
+                            if (hasNote) {
+                              toggleMpeNote(colIdx, midi);
+                              if (onPlayNote) {
+                                onPlayNote(midiToNoteName(midi));
+                                setFlashingNote(midi);
+                                setTimeout(() => setFlashingNote(null), 250);
+                              }
+                            } else {
+                              setMpeSelection([]);
+                            }
+                            return;
+                          }
+                          handleNoteClick(midi, colIdx, hasNote);
+                        }}
                         onDoubleClick={() => handleDoubleClick(midi, colIdx, hasNote)}
                         onPointerDown={(e) => handlePointerDown(e, midi, colIdx, hasNote)}
                         onPointerEnter={() => handlePointerEnterCell(midi, colIdx)}
@@ -583,6 +986,21 @@ export function InteractivePianoRoll({
                 <div key={midi} className={clsx("note-cell", !isWhiteKey(midi) && "black-row")} />
               ))}
             </div>
+          )}
+
+          {/* Expression curves overlay — draws pitch bends aligned to the grid.
+              Renders nothing when no expression exists, so the roll is
+              unchanged until the user authors a bend. */}
+          {mpeAvailable && (
+            <ExpressionOverlay
+              chords={chords}
+              noteRange={noteRange}
+              geom={geom}
+              mpeMode={mpeMode}
+              selection={mpeSelection}
+              containerRef={gridRef}
+              onUpdateSegment={handleUpdateSegment}
+            />
           )}
 
           {/* Playhead line */}

--- a/components/creative/MpeToolbar.tsx
+++ b/components/creative/MpeToolbar.tsx
@@ -1,0 +1,444 @@
+"use client";
+
+/**
+ * MpeToolbar — a compact, icon-first expression toolbar that sits above the
+ * piano roll while the MPE Editor mode is active. Its available actions adapt to
+ * the current note/chord selection so a musician can express an idea in seconds.
+ */
+
+import React, { useState } from "react";
+import clsx from "clsx";
+import {
+  MousePointer2,
+  Link2,
+  Spline,
+  Activity,
+  ChevronsDown,
+  ChevronsUp,
+  RotateCcw,
+  MoreHorizontal,
+  Copy,
+  ClipboardPaste,
+  Trash2,
+  FlipHorizontal2,
+  Maximize2,
+  Minimize2,
+  Clock,
+} from "lucide-react";
+import {
+  GLIDE_PRESET_LABELS,
+  DEFAULT_DROP,
+  DEFAULT_SCOOP,
+  DEFAULT_VIBRATO,
+  type GlidePreset,
+  type PitchDropOptions,
+  type PitchScoopOptions,
+  type VibratoOptions,
+} from "@/lib/expression/presets";
+
+export type MpeSelectionKind =
+  | "none"
+  | "one-note"
+  | "multi-notes"
+  | "two-notes"
+  | "two-chords"
+  | "two-chords-unequal";
+
+export interface MpeToolbarProps {
+  selectionKind: MpeSelectionKind;
+  selectionCount: number;
+  hasExpression: boolean;
+  canPaste: boolean;
+  onGlide: (preset: GlidePreset) => void;
+  onPitchDrop: (opts: PitchDropOptions) => void;
+  onScoop: (opts: PitchScoopOptions) => void;
+  onVibrato: (opts: VibratoOptions) => void;
+  onJoin: () => void;
+  onReset: () => void;
+  onReverse: () => void;
+  onScaleAmount: (factor: number) => void;
+  onScaleDuration: (factor: number) => void;
+  onCopy: () => void;
+  onPaste: () => void;
+  onDuplicate: () => void;
+  onRemove: () => void;
+}
+
+type OpenPanel = "glide" | "drop" | "scoop" | "vibrato" | "more" | null;
+
+function ToolButton({
+  icon,
+  label,
+  active,
+  disabled,
+  onClick,
+  title,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  active?: boolean;
+  disabled?: boolean;
+  onClick?: () => void;
+  title?: string;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      title={title ?? label}
+      className={clsx(
+        "flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border text-xs font-medium transition-colors shrink-0",
+        active
+          ? "border-accent/50 bg-accent/10 text-accent"
+          : "border-border-subtle bg-surface text-muted hover:border-accent/50 hover:text-accent",
+        disabled && "opacity-40 cursor-not-allowed hover:border-border-subtle hover:text-muted"
+      )}
+    >
+      {icon}
+      <span className="hidden sm:inline">{label}</span>
+    </button>
+  );
+}
+
+function Slider({
+  label,
+  value,
+  min,
+  max,
+  step,
+  suffix,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  suffix?: string;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-[11px] text-muted">
+      <span className="flex justify-between">
+        <span>{label}</span>
+        <span className="font-mono text-foreground">
+          {value}
+          {suffix ?? ""}
+        </span>
+      </span>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="accent-accent"
+      />
+    </label>
+  );
+}
+
+function Popover({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="absolute left-0 top-full mt-1 z-30 w-56 rounded-xl border border-border-subtle bg-surface p-3 shadow-lg">
+      {children}
+    </div>
+  );
+}
+
+export function MpeToolbar(props: MpeToolbarProps) {
+  const { selectionKind, selectionCount, hasExpression, canPaste } = props;
+  const [panel, setPanel] = useState<OpenPanel>(null);
+  const [drop, setDrop] = useState<PitchDropOptions>(DEFAULT_DROP);
+  const [scoop, setScoop] = useState<PitchScoopOptions>(DEFAULT_SCOOP);
+  const [vib, setVib] = useState<VibratoOptions>(DEFAULT_VIBRATO);
+
+  const toggle = (p: OpenPanel) => setPanel((cur) => (cur === p ? null : p));
+
+  // Which single-note gestures are available. Any live selection of notes can
+  // receive glide/drop/scoop/vibrato (applied to each selected note).
+  const hasNotes = selectionCount > 0;
+  const canJoin = selectionKind === "two-notes" || selectionKind === "two-chords";
+
+  const hint = (() => {
+    if (selectionKind === "none") return "Select a note or chord to add expression";
+    if (selectionKind === "two-chords-unequal")
+      return "Auto voice pairing needs two equal-sized chords";
+    if (selectionKind === "two-chords") return "Join pairs notes by pitch order";
+    if (selectionKind === "two-notes") return "Join creates an editable pitch bend";
+    return null;
+  })();
+
+  return (
+    <div className="mpe-toolbar mb-2">
+      <div className="flex flex-wrap items-center gap-1.5">
+        {/* Select — the resting tool; shows the current selection count. */}
+        <ToolButton
+          icon={<MousePointer2 className="w-3.5 h-3.5" />}
+          label={selectionCount > 0 ? `Select (${selectionCount})` : "Select"}
+          active
+          title="Click notes or chord headers to select"
+        />
+
+        {/* Join — only when the selection is joinable. */}
+        <ToolButton
+          icon={<Link2 className="w-3.5 h-3.5" />}
+          label="Join"
+          disabled={!canJoin}
+          onClick={props.onJoin}
+          title={
+            canJoin
+              ? "Create a pitch bend between the selection"
+              : "Select two notes, or two equal-sized chords, to join"
+          }
+        />
+
+        {/* Glide shape presets */}
+        <div className="relative">
+          <ToolButton
+            icon={<Spline className="w-3.5 h-3.5" />}
+            label="Glide"
+            active={panel === "glide"}
+            disabled={!hasNotes}
+            onClick={() => toggle("glide")}
+          />
+          {panel === "glide" && (
+            <Popover>
+              <p className="text-[11px] font-semibold text-foreground mb-1.5">Glide shape</p>
+              <div className="flex flex-col gap-1">
+                {(Object.keys(GLIDE_PRESET_LABELS) as GlidePreset[]).map((p) => (
+                  <button
+                    key={p}
+                    type="button"
+                    onClick={() => {
+                      props.onGlide(p);
+                      setPanel(null);
+                    }}
+                    className="text-left text-xs px-2 py-1.5 rounded-md text-muted hover:bg-surface-muted hover:text-accent transition-colors"
+                  >
+                    {GLIDE_PRESET_LABELS[p]}
+                  </button>
+                ))}
+              </div>
+            </Popover>
+          )}
+        </div>
+
+        {/* Vibrato */}
+        <div className="relative">
+          <ToolButton
+            icon={<Activity className="w-3.5 h-3.5" />}
+            label="Vibrato"
+            active={panel === "vibrato"}
+            disabled={!hasNotes}
+            onClick={() => toggle("vibrato")}
+          />
+          {panel === "vibrato" && (
+            <Popover>
+              <p className="text-[11px] font-semibold text-foreground mb-2">Vibrato</p>
+              <div className="flex flex-col gap-2.5">
+                <Slider label="Depth" value={vib.depth} min={0.1} max={2} step={0.1} suffix=" st"
+                  onChange={(v) => setVib({ ...vib, depth: v })} />
+                <Slider label="Speed" value={vib.cycles} min={1} max={12} step={1} suffix=" cyc"
+                  onChange={(v) => setVib({ ...vib, cycles: v })} />
+                <Slider label="Fade in" value={vib.fadeIn} min={0} max={1} step={0.05}
+                  onChange={(v) => setVib({ ...vib, fadeIn: v })} />
+                <Slider label="Fade out" value={vib.fadeOut} min={0} max={1} step={0.05}
+                  onChange={(v) => setVib({ ...vib, fadeOut: v })} />
+                <Slider label="Region start" value={vib.region[0]} min={0} max={1} step={0.05}
+                  onChange={(v) => setVib({ ...vib, region: [v, vib.region[1]] })} />
+                <button
+                  type="button"
+                  onClick={() => {
+                    props.onVibrato(vib);
+                    setPanel(null);
+                  }}
+                  className="mt-1 w-full text-xs font-medium px-2 py-1.5 rounded-md bg-accent/15 text-accent hover:bg-accent/25 transition-colors"
+                >
+                  Apply vibrato
+                </button>
+              </div>
+            </Popover>
+          )}
+        </div>
+
+        {/* Pitch Drop */}
+        <div className="relative">
+          <ToolButton
+            icon={<ChevronsDown className="w-3.5 h-3.5" />}
+            label="Drop"
+            active={panel === "drop"}
+            disabled={!hasNotes}
+            onClick={() => toggle("drop")}
+          />
+          {panel === "drop" && (
+            <Popover>
+              <p className="text-[11px] font-semibold text-foreground mb-2">Pitch drop</p>
+              <div className="flex flex-col gap-2.5">
+                <Slider label="Amount" value={drop.amount} min={1} max={24} step={1} suffix=" st"
+                  onChange={(v) => setDrop({ ...drop, amount: v })} />
+                <Slider label="Duration" value={drop.duration} min={0.05} max={1} step={0.05}
+                  onChange={(v) => setDrop({ ...drop, duration: v })} />
+                <div className="flex gap-1">
+                  {(["start", "end"] as const).map((pos) => (
+                    <button
+                      key={pos}
+                      type="button"
+                      onClick={() => setDrop({ ...drop, position: pos })}
+                      className={clsx(
+                        "flex-1 text-[11px] px-2 py-1 rounded-md border capitalize transition-colors",
+                        drop.position === pos
+                          ? "border-accent/50 bg-accent/10 text-accent"
+                          : "border-border-subtle text-muted hover:text-accent"
+                      )}
+                    >
+                      {pos}
+                    </button>
+                  ))}
+                </div>
+                <div className="flex gap-1">
+                  {(["smooth", "linear"] as const).map((c) => (
+                    <button
+                      key={c}
+                      type="button"
+                      onClick={() => setDrop({ ...drop, curve: c })}
+                      className={clsx(
+                        "flex-1 text-[11px] px-2 py-1 rounded-md border capitalize transition-colors",
+                        drop.curve === c
+                          ? "border-accent/50 bg-accent/10 text-accent"
+                          : "border-border-subtle text-muted hover:text-accent"
+                      )}
+                    >
+                      {c}
+                    </button>
+                  ))}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    props.onPitchDrop(drop);
+                    setPanel(null);
+                  }}
+                  className="mt-1 w-full text-xs font-medium px-2 py-1.5 rounded-md bg-accent/15 text-accent hover:bg-accent/25 transition-colors"
+                >
+                  Apply drop
+                </button>
+              </div>
+            </Popover>
+          )}
+        </div>
+
+        {/* Pitch Scoop */}
+        <div className="relative">
+          <ToolButton
+            icon={<ChevronsUp className="w-3.5 h-3.5" />}
+            label="Scoop"
+            active={panel === "scoop"}
+            disabled={!hasNotes}
+            onClick={() => toggle("scoop")}
+          />
+          {panel === "scoop" && (
+            <Popover>
+              <p className="text-[11px] font-semibold text-foreground mb-2">Pitch scoop</p>
+              <div className="flex flex-col gap-2.5">
+                <Slider label="Amount" value={scoop.amount} min={1} max={12} step={1} suffix=" st"
+                  onChange={(v) => setScoop({ ...scoop, amount: v })} />
+                <Slider label="Duration" value={scoop.duration} min={0.05} max={1} step={0.05}
+                  onChange={(v) => setScoop({ ...scoop, duration: v })} />
+                <button
+                  type="button"
+                  onClick={() => {
+                    props.onScoop(scoop);
+                    setPanel(null);
+                  }}
+                  className="mt-1 w-full text-xs font-medium px-2 py-1.5 rounded-md bg-accent/15 text-accent hover:bg-accent/25 transition-colors"
+                >
+                  Apply scoop
+                </button>
+              </div>
+            </Popover>
+          )}
+        </div>
+
+        {/* Reset */}
+        <ToolButton
+          icon={<RotateCcw className="w-3.5 h-3.5" />}
+          label="Reset"
+          disabled={!hasExpression}
+          onClick={props.onReset}
+          title="Remove expression from the selection"
+        />
+
+        {/* More… */}
+        <div className="relative">
+          <ToolButton
+            icon={<MoreHorizontal className="w-3.5 h-3.5" />}
+            label="More"
+            active={panel === "more"}
+            onClick={() => toggle("more")}
+          />
+          {panel === "more" && (
+            <Popover>
+              <div className="flex flex-col gap-0.5">
+                <MoreItem icon={<Copy className="w-3.5 h-3.5" />} label="Copy expression"
+                  disabled={!hasExpression} onClick={() => { props.onCopy(); setPanel(null); }} />
+                <MoreItem icon={<ClipboardPaste className="w-3.5 h-3.5" />} label="Paste expression"
+                  disabled={!canPaste || !hasNotes} onClick={() => { props.onPaste(); setPanel(null); }} />
+                <MoreItem icon={<Copy className="w-3.5 h-3.5" />} label="Duplicate to selection"
+                  disabled={!hasExpression || selectionCount < 2} onClick={() => { props.onDuplicate(); setPanel(null); }} />
+                <div className="my-1 border-t border-border-subtle" />
+                <MoreItem icon={<FlipHorizontal2 className="w-3.5 h-3.5" />} label="Reverse curve"
+                  disabled={!hasExpression} onClick={() => { props.onReverse(); setPanel(null); }} />
+                <MoreItem icon={<Maximize2 className="w-3.5 h-3.5" />} label="Scale amount +"
+                  disabled={!hasExpression} onClick={() => props.onScaleAmount(1.25)} />
+                <MoreItem icon={<Minimize2 className="w-3.5 h-3.5" />} label="Scale amount −"
+                  disabled={!hasExpression} onClick={() => props.onScaleAmount(0.8)} />
+                <MoreItem icon={<Clock className="w-3.5 h-3.5" />} label="Scale duration +"
+                  disabled={!hasExpression} onClick={() => props.onScaleDuration(1.25)} />
+                <MoreItem icon={<Clock className="w-3.5 h-3.5" />} label="Scale duration −"
+                  disabled={!hasExpression} onClick={() => props.onScaleDuration(0.8)} />
+                <div className="my-1 border-t border-border-subtle" />
+                <MoreItem icon={<Trash2 className="w-3.5 h-3.5" />} label="Remove expression" danger
+                  disabled={!hasExpression} onClick={() => { props.onRemove(); setPanel(null); }} />
+              </div>
+            </Popover>
+          )}
+        </div>
+      </div>
+
+      {hint && <p className="mt-1.5 text-[11px] text-muted/80">{hint}</p>}
+    </div>
+  );
+}
+
+function MoreItem({
+  icon,
+  label,
+  disabled,
+  danger,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  disabled?: boolean;
+  danger?: boolean;
+  onClick?: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className={clsx(
+        "flex items-center gap-2 text-left text-xs px-2 py-1.5 rounded-md transition-colors",
+        danger ? "text-rose-400 hover:bg-rose-500/10" : "text-muted hover:bg-surface-muted hover:text-accent",
+        disabled && "opacity-40 cursor-not-allowed hover:bg-transparent"
+      )}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}

--- a/lib/expression/__tests__/expression.test.ts
+++ b/lib/expression/__tests__/expression.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import {
+  glideCurve,
+  pitchDropCurve,
+  pitchScoopCurve,
+  vibratoCurve,
+  toSegment,
+} from "../presets";
+import {
+  buildSvgPath,
+  insertPointAt,
+  removePointAt,
+  reversePoints,
+  sampleY,
+  scaleAmount,
+  scaleDuration,
+  sortPoints,
+} from "../curve";
+
+describe("glideCurve", () => {
+  it("linear join has two endpoints landing exactly on the target", () => {
+    const { points, smooth } = glideCurve("join", 5);
+    expect(smooth).toBe(false);
+    expect(points[0]).toEqual({ t: 0, y: 0 });
+    expect(points[points.length - 1]).toEqual({ t: 1, y: 5 });
+  });
+
+  it("respects the sign of the target (downward glide)", () => {
+    const { points } = glideCurve("smooth", -3);
+    expect(points[0].y).toBe(0);
+    expect(points[points.length - 1].y).toBe(-3);
+  });
+
+  it("exponential rise ends on the target and is monotonic in |y|", () => {
+    const { points } = glideCurve("expRise", 12);
+    expect(points[0].y).toBeCloseTo(0);
+    expect(points[points.length - 1].y).toBeCloseTo(12);
+    for (let i = 1; i < points.length; i++) {
+      expect(points[i].y).toBeGreaterThanOrEqual(points[i - 1].y - 1e-9);
+    }
+  });
+});
+
+describe("pitchDropCurve / pitchScoopCurve", () => {
+  it("drop at end holds pitch then falls below", () => {
+    const { points } = pitchDropCurve({ amount: 12, duration: 0.3, position: "end", curve: "smooth" });
+    expect(points[0].y).toBe(0);
+    expect(points[points.length - 1].y).toBe(-12);
+    // the pre-drop point is still at pitch
+    expect(points[1].y).toBe(0);
+  });
+
+  it("drop amount is always downward regardless of sign", () => {
+    const { points } = pitchDropCurve({ amount: -8, duration: 0.5, position: "start", curve: "linear" });
+    expect(Math.min(...points.map((p) => p.y))).toBe(-8);
+  });
+
+  it("scoop begins below and settles to pitch", () => {
+    const { points } = pitchScoopCurve({ amount: 3, duration: 0.3, curve: "smooth" });
+    expect(points[0].y).toBe(-3);
+    expect(points[points.length - 1].y).toBe(0);
+  });
+});
+
+describe("vibratoCurve", () => {
+  it("stays within depth and starts/ends flat", () => {
+    const { points } = vibratoCurve({ depth: 0.5, cycles: 4, region: [0.2, 1], fadeIn: 0.2, fadeOut: 0.1 });
+    expect(points[0]).toEqual({ t: 0, y: 0 });
+    expect(points[points.length - 1].y).toBeCloseTo(0);
+    for (const p of points) {
+      expect(Math.abs(p.y)).toBeLessThanOrEqual(0.5 + 1e-9);
+    }
+  });
+
+  it("normalizes an inverted region", () => {
+    const { points } = vibratoCurve({ depth: 1, cycles: 2, region: [0.9, 0.3], fadeIn: 0, fadeOut: 0 });
+    const ts = points.map((p) => p.t);
+    // sorted and within [0,1]
+    for (let i = 1; i < ts.length; i++) expect(ts[i]).toBeGreaterThanOrEqual(ts[i - 1]);
+    expect(Math.min(...ts)).toBeGreaterThanOrEqual(0);
+    expect(Math.max(...ts)).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("curve operations", () => {
+  const base = [
+    { t: 0, y: 0 },
+    { t: 0.5, y: 2 },
+    { t: 1, y: 4 },
+  ];
+
+  it("sampleY interpolates linearly between points", () => {
+    expect(sampleY(base, 0.25)).toBeCloseTo(1);
+    expect(sampleY(base, 0.75)).toBeCloseTo(3);
+    expect(sampleY(base, -1)).toBe(0);
+    expect(sampleY(base, 2)).toBe(4);
+  });
+
+  it("insertPointAt snaps the new point onto the existing curve", () => {
+    const next = insertPointAt(base, 0.25);
+    const inserted = next.find((p) => Math.abs(p.t - 0.25) < 1e-9);
+    expect(inserted?.y).toBeCloseTo(1);
+    expect(next.length).toBe(4);
+  });
+
+  it("removePointAt never removes endpoints", () => {
+    expect(removePointAt(base, 0).length).toBe(3);
+    expect(removePointAt(base, 2).length).toBe(3);
+    expect(removePointAt(base, 1).length).toBe(2);
+  });
+
+  it("reversePoints mirrors time", () => {
+    const r = reversePoints(base);
+    expect(r[0]).toEqual({ t: 0, y: 4 });
+    expect(r[r.length - 1]).toEqual({ t: 1, y: 0 });
+  });
+
+  it("scaleAmount scales only y", () => {
+    const s = scaleAmount(base, 2);
+    expect(s.map((p) => p.y)).toEqual([0, 4, 8]);
+    expect(s.map((p) => p.t)).toEqual([0, 0.5, 1]);
+  });
+
+  it("scaleDuration compresses time toward the start, clamped to 1", () => {
+    const s = sortPoints(scaleDuration(base, 0.5));
+    expect(s[0].t).toBe(0);
+    expect(s[1].t).toBeCloseTo(0.25);
+    expect(s[2].t).toBeCloseTo(0.5);
+    const stretched = scaleDuration(base, 4);
+    expect(Math.max(...stretched.map((p) => p.t))).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("buildSvgPath", () => {
+  it("produces a straight polyline when not smooth", () => {
+    const d = buildSvgPath([{ x: 0, y: 0 }, { x: 10, y: 5 }], false);
+    expect(d).toContain("M 0 0");
+    expect(d).toContain("L 10 5");
+  });
+
+  it("uses cubic beziers when smooth", () => {
+    const d = buildSvgPath([{ x: 0, y: 0 }, { x: 5, y: 5 }, { x: 10, y: 0 }], true);
+    expect(d.startsWith("M 0 0")).toBe(true);
+    expect(d).toContain("C ");
+  });
+
+  it("returns empty for < 2 points", () => {
+    expect(buildSvgPath([{ x: 0, y: 0 }], true)).toBe("");
+  });
+});
+
+describe("toSegment", () => {
+  it("wraps a curve into a pitch-lane segment with a unique id", () => {
+    const a = toSegment("glide", glideCurve("join", 2));
+    const b = toSegment("glide", glideCurve("join", 2));
+    expect(a.lane).toBe("pitch");
+    expect(a.kind).toBe("glide");
+    expect(a.id).not.toBe(b.id);
+    expect(a.points.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/lib/expression/curve.ts
+++ b/lib/expression/curve.ts
@@ -1,0 +1,122 @@
+/**
+ * MPE Expression Editor — Curve helpers
+ *
+ * Geometry-agnostic operations on expression point arrays plus an SVG path
+ * builder that turns already-projected pixel points into a `d` attribute.
+ * Nothing here touches the DOM or the store — pure functions, easy to test.
+ */
+
+import type { ExpressionPoint } from "./types";
+
+let segIdCounter = 0;
+/** Stable-enough unique id for a segment (browser-only usage). */
+export function makeSegmentId(): string {
+  segIdCounter += 1;
+  return `expr-${Date.now().toString(36)}-${segIdCounter}`;
+}
+
+export function clamp(v: number, lo: number, hi: number): number {
+  return v < lo ? lo : v > hi ? hi : v;
+}
+
+/** Return a copy sorted ascending by `t`. */
+export function sortPoints(points: ExpressionPoint[]): ExpressionPoint[] {
+  return [...points].sort((a, b) => a.t - b.t);
+}
+
+/**
+ * Linearly sample the value of a curve at time `t` (0..1). Used when inserting a
+ * new control point so it lands on the existing line, and as a simple baker for
+ * future playback/export. Smooth rendering is a visual concern handled by the
+ * SVG path builder; sampling stays linear so it is monotonic and predictable.
+ */
+export function sampleY(points: ExpressionPoint[], t: number): number {
+  if (points.length === 0) return 0;
+  const pts = sortPoints(points);
+  if (t <= pts[0].t) return pts[0].y;
+  if (t >= pts[pts.length - 1].t) return pts[pts.length - 1].y;
+  for (let i = 0; i < pts.length - 1; i++) {
+    const a = pts[i];
+    const b = pts[i + 1];
+    if (t >= a.t && t <= b.t) {
+      const span = b.t - a.t;
+      if (span <= 0) return a.y;
+      const f = (t - a.t) / span;
+      return a.y + (b.y - a.y) * f;
+    }
+  }
+  return pts[pts.length - 1].y;
+}
+
+/** Insert a control point at time `t`, snapping its value onto the current curve. */
+export function insertPointAt(points: ExpressionPoint[], t: number): ExpressionPoint[] {
+  const ct = clamp(t, 0, 1);
+  const y = sampleY(points, ct);
+  return sortPoints([...points, { t: ct, y }]);
+}
+
+/**
+ * Remove the point at `index`, but never the two endpoints — a curve always
+ * keeps at least a start and an end.
+ */
+export function removePointAt(points: ExpressionPoint[], index: number): ExpressionPoint[] {
+  if (points.length <= 2) return points;
+  if (index <= 0 || index >= points.length - 1) return points;
+  return points.filter((_, i) => i !== index);
+}
+
+/** Reverse the curve in time (mirror across the vertical mid-line). */
+export function reversePoints(points: ExpressionPoint[]): ExpressionPoint[] {
+  return sortPoints(points.map((p) => ({ t: 1 - p.t, y: p.y })));
+}
+
+/** Scale the pitch/value amount of the whole curve by `factor`. */
+export function scaleAmount(points: ExpressionPoint[], factor: number): ExpressionPoint[] {
+  return points.map((p) => ({ t: p.t, y: p.y * factor }));
+}
+
+/**
+ * Scale the curve's time footprint by `factor`, anchored at the note start.
+ * factor < 1 compresses the gesture toward the beginning; factor > 1 stretches
+ * it toward the end (clamped to the note).
+ */
+export function scaleDuration(points: ExpressionPoint[], factor: number): ExpressionPoint[] {
+  return sortPoints(points.map((p) => ({ t: clamp(p.t * factor, 0, 1), y: p.y })));
+}
+
+// ─── SVG path building (pixel space) ───
+
+export interface PixelPoint {
+  x: number;
+  y: number;
+}
+
+/**
+ * Build an SVG path `d` string from projected pixel points. When `smooth`, uses
+ * a Catmull-Rom → cubic-Bézier conversion for a natural, non-overshooting curve;
+ * otherwise draws straight segments.
+ */
+export function buildSvgPath(pts: PixelPoint[], smooth: boolean): string {
+  if (pts.length < 2) return "";
+  if (!smooth) {
+    return `M ${pts[0].x} ${pts[0].y} ` + pts.slice(1).map((p) => `L ${p.x} ${p.y}`).join(" ");
+  }
+
+  let d = `M ${pts[0].x} ${pts[0].y}`;
+  for (let i = 0; i < pts.length - 1; i++) {
+    const p0 = pts[i - 1] ?? pts[i];
+    const p1 = pts[i];
+    const p2 = pts[i + 1];
+    const p3 = pts[i + 2] ?? p2;
+
+    // Catmull-Rom to Bézier (tension 0). Control points sit 1/6 of the way
+    // along the neighbouring chords, which keeps the spline tight to the data.
+    const c1x = p1.x + (p2.x - p0.x) / 6;
+    const c1y = p1.y + (p2.y - p0.y) / 6;
+    const c2x = p2.x - (p3.x - p1.x) / 6;
+    const c2y = p2.y - (p3.y - p1.y) / 6;
+
+    d += ` C ${c1x} ${c1y}, ${c2x} ${c2y}, ${p2.x} ${p2.y}`;
+  }
+  return d;
+}

--- a/lib/expression/presets.ts
+++ b/lib/expression/presets.ts
@@ -1,0 +1,197 @@
+/**
+ * MPE Expression Editor — Musical presets
+ *
+ * Generators that turn a musical intent (a glide shape, a pitch drop, a scoop,
+ * a vibrato region) into an editable set of control points. Presets are just
+ * convenient starting points — every curve they produce is fully editable
+ * afterwards by dragging handles, inserting/deleting points, and smoothing or
+ * straightening.
+ *
+ * The pitch lane measures `y` in semitones relative to the note's base pitch.
+ */
+
+import type { ExpressionPoint, ExpressionSegment, ExpressionKind } from "./types";
+import { clamp, makeSegmentId, sortPoints } from "./curve";
+
+export interface GeneratedCurve {
+  points: ExpressionPoint[];
+  smooth: boolean;
+}
+
+/** Glide/transition shapes that move from the note's pitch to `target` semitones. */
+export type GlidePreset =
+  | "join"
+  | "smooth"
+  | "easeIn"
+  | "easeOut"
+  | "expRise"
+  | "expFall";
+
+export const GLIDE_PRESET_LABELS: Record<GlidePreset, string> = {
+  join: "Join (linear)",
+  smooth: "Smooth Glide",
+  easeIn: "Ease In",
+  easeOut: "Ease Out",
+  expRise: "Exponential Rise",
+  expFall: "Exponential Fall",
+};
+
+/**
+ * Build the control points for a glide of `target` semitones (positive = up,
+ * negative = down). `expRise`/`expFall` follow an exponential contour; their
+ * naming reflects the typical direction but the actual `target` sign is honoured
+ * so either can bend either way.
+ */
+export function glideCurve(preset: GlidePreset, target: number): GeneratedCurve {
+  switch (preset) {
+    case "join":
+      return { points: [{ t: 0, y: 0 }, { t: 1, y: target }], smooth: false };
+    case "smooth":
+      return {
+        points: [{ t: 0, y: 0 }, { t: 0.5, y: target * 0.5 }, { t: 1, y: target }],
+        smooth: true,
+      };
+    case "easeIn":
+      // Slow start: stays near the origin, then accelerates to the target.
+      return {
+        points: [{ t: 0, y: 0 }, { t: 0.65, y: target * 0.18 }, { t: 1, y: target }],
+        smooth: true,
+      };
+    case "easeOut":
+      // Slow finish: rushes toward the target, then settles.
+      return {
+        points: [{ t: 0, y: 0 }, { t: 0.35, y: target * 0.82 }, { t: 1, y: target }],
+        smooth: true,
+      };
+    case "expRise":
+    case "expFall": {
+      const pts: ExpressionPoint[] = [];
+      const steps = 6;
+      for (let i = 0; i <= steps; i++) {
+        const t = i / steps;
+        // Normalized exponential 0→1 with a firm knee.
+        const shaped = (Math.pow(4, t) - 1) / 3;
+        pts.push({ t, y: target * shaped });
+      }
+      return { points: pts, smooth: true };
+    }
+  }
+}
+
+export interface PitchDropOptions {
+  /** Semitones dropped below the note (always applied downward). */
+  amount: number;
+  /** Fraction of the note the drop occupies, 0..1. */
+  duration: number;
+  /** Whether the drop lands at the note's start or its end. */
+  position: "start" | "end";
+  /** Curve feel. */
+  curve: "linear" | "smooth";
+}
+
+/** A downward pitch drop — great for basses, growls, and cinematic impacts. */
+export function pitchDropCurve(opts: PitchDropOptions): GeneratedCurve {
+  const d = clamp(opts.duration, 0.05, 1);
+  const a = -Math.abs(opts.amount);
+  const smooth = opts.curve !== "linear";
+  if (opts.position === "start") {
+    // Fall away from pitch immediately, then hold low.
+    return { points: [{ t: 0, y: 0 }, { t: d, y: a }, { t: 1, y: a }], smooth };
+  }
+  // Hold pitch, then drop into the tail.
+  return { points: [{ t: 0, y: 0 }, { t: 1 - d, y: 0 }, { t: 1, y: a }], smooth };
+}
+
+export interface PitchScoopOptions {
+  /** Semitones the note starts below its target pitch. */
+  amount: number;
+  /** Fraction of the note spent settling up to pitch, 0..1. */
+  duration: number;
+  curve: "linear" | "smooth";
+}
+
+/** Inverse of a drop: begin below the target pitch, then settle up to it. */
+export function pitchScoopCurve(opts: PitchScoopOptions): GeneratedCurve {
+  const d = clamp(opts.duration, 0.05, 1);
+  const a = -Math.abs(opts.amount);
+  const smooth = opts.curve !== "linear";
+  return { points: [{ t: 0, y: a }, { t: d, y: 0 }, { t: 1, y: 0 }], smooth };
+}
+
+export interface VibratoOptions {
+  /** Peak depth in semitones. */
+  depth: number;
+  /** Number of oscillation cycles across the region. */
+  cycles: number;
+  /** Region of the note the vibrato covers, as [start, end] in 0..1. */
+  region: [number, number];
+  /** Fraction of the region used to fade the depth in (0..1). */
+  fadeIn: number;
+  /** Fraction of the region used to fade the depth out (0..1). */
+  fadeOut: number;
+}
+
+/**
+ * A vibrato oscillation confined to `region`, with optional depth fades at each
+ * end. Points outside the region sit flat at 0 so the note holds pitch there.
+ */
+export function vibratoCurve(opts: VibratoOptions): GeneratedCurve {
+  const [r0raw, r1raw] = opts.region;
+  const r0 = clamp(Math.min(r0raw, r1raw), 0, 1);
+  const r1 = clamp(Math.max(r0raw, r1raw), 0, 1);
+  const cycles = Math.max(0.5, opts.cycles);
+  const depth = Math.abs(opts.depth);
+  const fadeIn = clamp(opts.fadeIn, 0, 1);
+  const fadeOut = clamp(opts.fadeOut, 0, 1);
+
+  const pts: ExpressionPoint[] = [{ t: 0, y: 0 }];
+  if (r0 > 0.001) pts.push({ t: r0, y: 0 });
+
+  const samples = Math.max(4, Math.round(cycles * 8));
+  for (let i = 0; i <= samples; i++) {
+    const localT = i / samples; // 0..1 across the region
+    const t = r0 + (r1 - r0) * localT;
+    let amp = depth;
+    if (fadeIn > 0 && localT < fadeIn) amp *= localT / fadeIn;
+    if (fadeOut > 0 && localT > 1 - fadeOut) amp *= (1 - localT) / fadeOut;
+    const y = Math.sin(localT * cycles * 2 * Math.PI) * amp;
+    pts.push({ t, y });
+  }
+
+  if (r1 < 0.999) pts.push({ t: r1, y: 0 });
+  pts.push({ t: 1, y: 0 });
+  return { points: sortPoints(pts), smooth: true };
+}
+
+/** Wrap a generated curve into a full segment ready for the store. */
+export function toSegment(kind: ExpressionKind, curve: GeneratedCurve): ExpressionSegment {
+  return {
+    id: makeSegmentId(),
+    lane: "pitch",
+    kind,
+    points: curve.points,
+    smooth: curve.smooth,
+  };
+}
+
+// ─── Sensible defaults for one-click application ───
+
+export const DEFAULT_GLIDE_TARGET = 2; // a whole step up, editable afterwards
+export const DEFAULT_DROP: PitchDropOptions = {
+  amount: 12,
+  duration: 0.35,
+  position: "end",
+  curve: "smooth",
+};
+export const DEFAULT_SCOOP: PitchScoopOptions = {
+  amount: 3,
+  duration: 0.3,
+  curve: "smooth",
+};
+export const DEFAULT_VIBRATO: VibratoOptions = {
+  depth: 0.5,
+  cycles: 4,
+  region: [0.3, 1],
+  fadeIn: 0.25,
+  fadeOut: 0.1,
+};

--- a/lib/expression/types.ts
+++ b/lib/expression/types.ts
@@ -1,0 +1,64 @@
+/**
+ * MPE Expression Editor — Data Model
+ *
+ * Expressive per-note automation (pitch bends, and — in the future — pressure,
+ * timbre, slide, and CC lanes). Pitch is the first supported lane; the shapes
+ * below are intentionally lane-generic so additional expressive dimensions can
+ * reuse the same architecture without a redesign.
+ *
+ * All of this data is stored and visualized independently of playback. If/when
+ * Harmonia gains real-time pitch automation or MIDI/MPE export, these segments
+ * are the source of truth to render from — nothing here depends on playback
+ * being implemented first.
+ */
+
+/** Expressive dimensions. Only "pitch" is authored today; the rest are reserved. */
+export type ExpressionLane =
+  | "pitch"
+  | "pressure"
+  | "timbre"
+  | "expression"
+  | "slide"
+  | "cc";
+
+/** How a segment was produced — drives labelling and default editing affordances. */
+export type ExpressionKind =
+  | "glide"
+  | "drop"
+  | "scoop"
+  | "vibrato"
+  | "custom";
+
+/**
+ * A single control point on an expression curve.
+ *   - `t`: normalized position across the note's duration (0 = note start, 1 = note end).
+ *   - `y`: value offset in the lane's units. For the pitch lane this is a
+ *          semitone offset from the note's base pitch (fractional allowed;
+ *          positive = higher). +1 semitone renders exactly one piano-roll row up.
+ */
+export interface ExpressionPoint {
+  t: number;
+  y: number;
+}
+
+/**
+ * One expressive segment attached to a note. A note may carry several segments
+ * (e.g. a glide plus a vibrato region), though the toolbar authors one at a time.
+ */
+export interface ExpressionSegment {
+  id: string;
+  lane: ExpressionLane;
+  kind: ExpressionKind;
+  /** Ordered by `t`, length >= 2. The first/last points are the curve endpoints. */
+  points: ExpressionPoint[];
+  /** true → smooth (spline) interpolation between points; false → straight lines. */
+  smooth: boolean;
+}
+
+/**
+ * Expression data for a chord, keyed by the note's MIDI number. Keeping the key
+ * as the MIDI value (rather than an index) means the mapping survives voicing
+ * reorders; stale keys for notes that no longer exist are simply ignored when
+ * rendering.
+ */
+export type ChordExpression = Record<number, ExpressionSegment[]>;

--- a/lib/state/progressionStore.ts
+++ b/lib/state/progressionStore.ts
@@ -14,6 +14,7 @@ import { getChordPitchClasses, normalizeRoot } from "../theory/chordSymbol";
 import { getScaleDefinition } from "../theory/scale";
 import type { ScaleType } from "../theory/types";
 import { makeSpeller, type Speller } from "../theory/spelling";
+import type { ExpressionSegment } from "../expression/types";
 
 const MODE_TO_SCALE: Record<Mode, ScaleType> = {
     ionian: "major",
@@ -110,6 +111,11 @@ interface ProgressionState {
     removeNote: (chordIndex: number, midi: number) => void;
     moveNote: (chordIndex: number, fromMidi: number, toMidi: number) => void;
     resetChord: (chordIndex: number) => void;
+
+    // MPE expression actions
+    setNoteSegments: (chordIndex: number, midi: number, segments: ExpressionSegment[]) => void;
+    removeNoteExpression: (chordIndex: number, midi: number) => void;
+    clearAllExpression: () => void;
 
     // Melody actions
     setMelodyEnabled: (enabled: boolean) => void;
@@ -617,6 +623,48 @@ export const useProgressionStore = create<ProgressionState>((set, get) => ({
         if (original) {
             get().revertChord(chordIndex);
         }
+    },
+
+    // ─── MPE Expression Actions ───
+    //
+    // Expression is stored on the chord (keyed by note MIDI) so it travels with
+    // the progression through save/load/history. Writes are immutable clones so
+    // Zustand subscribers re-render; empty segment lists are pruned to keep the
+    // "no expression" state byte-identical to a fresh chord.
+
+    setNoteSegments: (chordIndex: number, midi: number, segments: ExpressionSegment[]) => {
+        const { currentProgression } = get();
+        if (!currentProgression) return;
+        const chord = currentProgression.chords[chordIndex];
+        if (!chord) return;
+
+        const nextExpr = { ...(chord.expressions ?? {}) };
+        if (segments.length === 0) {
+            delete nextExpr[midi];
+        } else {
+            nextExpr[midi] = segments;
+        }
+        const hasAny = Object.keys(nextExpr).length > 0;
+
+        const chords = currentProgression.chords.map((c, i) =>
+            i === chordIndex
+                ? { ...c, expressions: hasAny ? nextExpr : undefined }
+                : c
+        );
+        set({ currentProgression: { ...currentProgression, chords } });
+    },
+
+    removeNoteExpression: (chordIndex: number, midi: number) => {
+        get().setNoteSegments(chordIndex, midi, []);
+    },
+
+    clearAllExpression: () => {
+        const { currentProgression } = get();
+        if (!currentProgression) return;
+        const chords = currentProgression.chords.map((c) =>
+            c.expressions ? { ...c, expressions: undefined } : c
+        );
+        set({ currentProgression: { ...currentProgression, chords } });
     },
 
     // ─── Melody Actions ───

--- a/lib/theory/progressionTypes.ts
+++ b/lib/theory/progressionTypes.ts
@@ -1,6 +1,7 @@
 import { PitchClass } from "../theory/midiUtils";
 import { ChordQuality, RomanNumeral } from "../theory/chord";
 import type { DurationClass } from "../music/generators/advanced/types";
+import type { ChordExpression } from "../expression/types";
 
 export interface Chord {
     symbol: string;
@@ -12,6 +13,12 @@ export interface Chord {
     quality?: ChordQuality;
     isLocked?: boolean;
     durationClass?: DurationClass;
+    /**
+     * Optional MPE expression data (pitch bends, and future lanes), keyed by the
+     * note's MIDI number. Absent unless the user has authored expression in the
+     * MPE Editor; stored/visualized independently of playback.
+     */
+    expressions?: ChordExpression;
 }
 
 export interface Progression {


### PR DESCRIPTION
## Overview

Adds a lightweight **MPE Expression Editor** to Harmonia's existing piano roll. Musicians can create expressive transitions — glides, bends, vibrato, scoops, and pitch drops — using visual pitch curves, without turning the app into a DAW. The editor is a **mode of the piano roll**, not a separate screen: the roll stays fully visible and, when no expression exists, looks identical to before.

Expression data is generated, stored, and visualized **independently of playback**, so real-time MPE playback / MIDI export can be added later without redesigning the feature.

## What's included

**Editing mode & toolbar**
- A `Piano Roll ⇄ MPE Editor` segmented toggle above the roll.
- A compact, icon-first toolbar (`Select · Join · Glide · Vibrato · Drop · Scoop · Reset · More…`) whose actions adapt to the current selection.

**Context-aware operations**
- **One note** → Pitch Drop, Scoop, Vibrato, Glide Shape, Reset.
- **Two notes** → **Join** creates an editable pitch bend between them.
- **Two equal-sized chords** → **Join** auto-pairs notes by pitch order (C→D, E→F♯, G→A) and gives each pair its own independent bend.
- **Unequal chords** → a friendly message explains that automatic voice pairing currently requires equal-sized chords.

**Editable curves (vector-style, not MIDI automation)**
- Pitch bends draw directly on the grid, aligned to note rows.
- Drag endpoints and control handles, double-click the line to insert a point, double-click a handle to delete it, plus Reverse / Scale Amount / Scale Duration / Smooth vs Straighten.
- Musical presets as starting points: Join (linear), Smooth Glide, Ease In, Ease Out, Exponential Rise/Fall; Pitch Drop (start/end, amount, duration, curve); Pitch Scoop; Vibrato (depth, speed, fade in/out, draggable region).
- Copy / Paste / Duplicate / Remove expression across the selection.

**Extensible data model**
- Each note may carry expression segments keyed by MIDI. The shapes are lane-generic (`pitch` today; `pressure`, `timbre`, `slide`, `cc` reserved) so future expressive dimensions reuse the same architecture.

## Changes

| Area | File(s) |
|------|---------|
| Data model | `lib/expression/types.ts` |
| Musical presets | `lib/expression/presets.ts` |
| Pure curve ops + SVG path builder | `lib/expression/curve.ts` |
| Canonical chord type | `lib/theory/progressionTypes.ts` (optional `expressions` field) |
| Store actions | `lib/state/progressionStore.ts` (`setNoteSegments`, `removeNoteExpression`, `clearAllExpression`) |
| SVG curve overlay + handle editing | `components/creative/ExpressionOverlay.tsx` |
| Context-aware toolbar | `components/creative/MpeToolbar.tsx` |
| Mode toggle, selection, geometry, Join | `components/creative/InteractivePianoRoll.tsx` |
| Wiring | `app/page.tsx` |
| Styles | `app/globals.css` |
| Docs | `README.md` |

## Testing

- **18 unit tests** for the preset/curve logic (`lib/expression/__tests__/expression.test.ts`) — all pass; full suite: 651 passing (the only failing files are pre-existing `_deferred/` archived tests unrelated to this change).
- `npm run lint` — clean.
- Production build compiles successfully (the sole type error is the pre-existing `lib/db.ts` Prisma issue noted in `CLAUDE.md`).
- End-to-end browser verification: generate a progression → MPE mode → select two notes / two chords → **Join** renders paired bends; presets apply; handles drag to reshape; double-click inserts/deletes points; curves remain visible (read-only) back in Piano Roll mode.

## Notes

- When no expression exists, the roll is byte-for-byte the same experience as before — the overlay renders nothing and normal note editing is unchanged.
- Note-pitch dragging is disabled in MPE mode so a drag reshapes the expression curve rather than moving the note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgmXDx39gne9UPhLMAMwAV

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgmXDx39gne9UPhLMAMwAV)_